### PR TITLE
add bundle_bin option

### DIFF
--- a/lib/mina/bundler.rb
+++ b/lib/mina/bundler.rb
@@ -1,4 +1,5 @@
 
+settings.bundle_bin ||= 'bundle'
 settings.bundle_path ||= './vendor/bundle'
 settings.bundle_options ||= lambda { %{--without development:test --path "#{bundle_path}" --binstubs bin/ --deployment} }
 
@@ -8,7 +9,7 @@ namespace :bundle do
     if bundle_path.nil?
       queue %{
         echo "-----> Installing gem dependencies using Bundler"
-        #{echo_cmd %[bundle install #{bundle_options}]}
+        #{echo_cmd %[#{bundle_bin} install #{bundle_options}]}
       }
     else
       queue %{
@@ -16,7 +17,7 @@ namespace :bundle do
         #{echo_cmd %[mkdir -p "#{deploy_to}/#{shared_path}/bundle"]}
         #{echo_cmd %[mkdir -p "#{File.dirname bundle_path}"]}
         #{echo_cmd %[ln -s "#{deploy_to}/#{shared_path}/bundle" "#{bundle_path}"]}
-        #{echo_cmd %[bundle install #{bundle_options}]}
+        #{echo_cmd %[#{bundle_bin} install #{bundle_options}]}
       }
     end
   end


### PR DESCRIPTION
I had an issue with mina where it wasn't picking up on the path for my gems so my deployments where failing on the bundle command.

This change just adds a `bundle_bin` option to allow you too set a custom path to the bundle binary. In my deploy.rb I use:

```
set :bundle_bin, '/var/lib/gems/1.8/bin/bundle'
```

which solves my problem.

Other than this mina working great :D thanks for writing this awesome tool!
