### PR TITLE
link_shared_paths task was creating relative links instead of absolute ones

### DIFF
--- a/lib/mina/deploy.rb
+++ b/lib/mina/deploy.rb
@@ -20,7 +20,7 @@ namespace :deploy do
     end
 
     cmds += shared_paths.map do |file|
-      echo_cmd %{ln -s "#{shared_path}/#{file}" "./#{file}"}
+      echo_cmd %{ln -s "#{deploy_to}/#{shared_path}/#{file}" "./#{file}"}
     end
 
     queue %{


### PR DESCRIPTION
When I tried to use this task, the resulting symlink was not pointing to the correct location. With this little patch, it works as intended.
