### PR TITLE
Fix string interpolation in :init task output

### DIFF
--- a/lib/mina/default.rb
+++ b/lib/mina/default.rb
@@ -16,7 +16,7 @@ task :init do
   FileUtils.cp Mina.root_path('data/deploy.rb'), './config/deploy.rb'
 
   puts 'Created deploy.rb.'
-  puts 'Edit it, then run `#{name} setup` after.'
+  puts "Edit it, then run `#{name} setup` after."
 end
 
 task :default => :help


### PR DESCRIPTION
Output message shows the right command hint. It was `#{name} setup` before fix. Now it's `mina setup`.

Thank you for nice tool, guys!
