### PR TITLE
Error when checking out to current_revision 

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -12,7 +12,7 @@ namespace :git do
       echo "-----> Cloning the Git repository"
       #{echo_cmd %[git clone "#{repository!}" . -n --recursive]} &&
       echo "-----> Using revision #{revision}" &&
-      #{echo_cmd %[git checkout "#{revision}" -b current_release 1>/dev/null]} &&
+      #{echo_cmd %[git checkout "origin/#{revision}" -b current_release 1>/dev/null]} &&
       #{echo_cmd %[rm -rf .git]}
     }
   end


### PR DESCRIPTION
set :revision, 'some-branch'
git checkout "some-branch" -b current_release 1>/dev/null

fatal: git checkout: updating paths is incompatible with switching branches.

$ git --version
git version 1.7.5.4
