### PR TITLE
Add in_directory directory, to execute commands within a particular path

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -239,7 +239,7 @@ module Mina
     #
     def in_directory(path, &blk)
       isolated_commands = isolate { yield; commands }
-      queue "cd #{path} && (#{isolated_commands.join('&&')})"
+      isolated_commands.each { |cmd| queue "(cd #{path} && (#{cmd}))" }
     end
 
     # Defines instructions on how to do a certain thing.


### PR DESCRIPTION
This is similar to Fabric's `with cd(path)` idiom.
