### PR TITLE
Add helpful error message when there is a problem with deploy.rb or a custom Rakefile

### DIFF
--- a/bin/mina
+++ b/bin/mina
@@ -42,7 +42,12 @@ Rake.application.instance_eval do
       require 'mina/rake'
 
       # Allow running without a Rakefile
-      load_rakefile  if have_rakefile || custom_rakefile
+      begin
+        load_rakefile  if have_rakefile || custom_rakefile
+      rescue Exception
+        puts "Error loading Rakefile!"
+        raise "There may be a problem with config/deploy.rb and/or Rakefile"
+      end
 
       # Run tasks
       top_level


### PR DESCRIPTION
Turns out a different developer already had a config/deploy.rb created to use Capistrano. The error message was not very useful (rake Task Argument Error) so this patch will hopefully help other people that run into this problem in the future.

fixes #36
