### PR TITLE
Implemented text file upload to the server and rendering of templates.

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -37,11 +37,11 @@ module Mina
     #
     def put(content, file)
       queue <<-CMD
-        export IFS=''
-        read -d '' MINA_PUT <<"EOF"
-        #{content}
-        EOF
-        echo $MINA_PUT > #{file}
+      export IFS=''
+      read -d '' MINA_PUT <<"EOF"
+      #{content}
+      EOF
+      echo $MINA_PUT > #{file}
       CMD
     end
 
@@ -334,7 +334,7 @@ module Mina
     end
 
     def indent(count, str)
-      str.gsub(/^/, " "*count)
+      str.gsub(/^(?!EOF$)/, " "*count)
     end
 
     def error(str)

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -31,6 +31,29 @@ module Mina
       erb.result b
     end
 
+    # Creates a file on the server with the given content
+    #
+    # put("This is my file", "/tmp/file")
+    #
+    def put(content, file)
+      queue <<-CMD
+        export IFS=''
+        read -d '' MINA_PUT <<"EOF"
+        #{content}
+        EOF
+        echo $MINA_PUT > #{file}
+      CMD
+    end
+
+    # Renders a template and uploads it to the server.
+    # Defaults to an ERB template.
+    #
+    # put("templates/my_template.erb", "/tmp/file")
+    #
+    def render(template, out, renderer=method(:erb))
+      put(renderer.call(template), out)
+    end
+
     # SSHs into the host and runs the code that has been queued.
     #
     # This is already automatically invoked before Rake exits to run all

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -37,10 +37,12 @@ module Mina
     #
     def put(content, file)
       queue <<-CMD
+      OLDIFS=$IFS
       IFS='' read -r -d '' MINA_PUT <<"EOF"
 #{content}
 EOF
       echo "$MINA_PUT" > #{file}
+      IFS=$OLDIFS
       CMD
     end
 

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -38,7 +38,7 @@ module Mina
     def put(content, file)
       queue <<-CMD
       export IFS=''
-      read -d '' MINA_PUT <<"EOF"
+      read -d '' MINA_PUT <<-"EOF"
       #{content}
       EOF
       echo $MINA_PUT > #{file}
@@ -334,7 +334,7 @@ module Mina
     end
 
     def indent(count, str)
-      str.gsub(/^(?!EOF$)/, " "*count)
+      str.gsub(/^(?!EOF$)/, "\t"*count)
     end
 
     def error(str)

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -37,11 +37,10 @@ module Mina
     #
     def put(content, file)
       queue <<-CMD
-      export IFS=''
-      read -d '' MINA_PUT <<-"EOF"
-      #{content}
-      EOF
-      echo $MINA_PUT > #{file}
+      IFS='' read -r -d '' MINA_PUT <<"EOF"
+#{content}
+EOF
+      echo "$MINA_PUT" > #{file}
       CMD
     end
 

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -48,7 +48,7 @@ module Mina
     # Renders a template and uploads it to the server.
     # Defaults to an ERB template.
     #
-    # put("templates/my_template.erb", "/tmp/file")
+    # render("templates/my_template.erb", "/tmp/file")
     #
     def render(template, out, renderer=method(:erb))
       put(renderer.call(template), out)


### PR DESCRIPTION
Hi all,

A common case scenario while deploying an app is to create configuration files on the fly such as a database config file.

I don't know how you're currently handling this and given the nature of how a Mina script runs you can't use scp (unless something like a reverse tunnel is created or something like [zssh's zr command](http://zssh.sourceforge.net/) is used).

On the current patch I'm using [*read*](http://serverfault.com/questions/72476/clean-way-to-write-complex-multi-line-string-to-a-variable) to read text files/content and echo them on the server to a file.

There're two methods:
* *put*, which allows random content to be uploaded to a file, and
* *render*, which renders a template and uploads it to the file (defaults to erb but anything can be used).

Perhaps, if there's a need to upload binary files scp could be used and a parallel connection open?

What do you think? Is this useful?
Thanks,
Darío