### PR TITLE
Rbenv

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -76,10 +76,7 @@ module Mina
     #
     def ssh(cmd, options={})
       cmd = cmd.join("\n")  if cmd.is_a?(Array)
-
-      if rbenv_loaded
-          cmd = load_rbenv(cmd)
-      end
+      cmd = load_rbenv(cmd) if defined? load_rbenv
 
       require 'shellwords'
 

--- a/lib/mina/rbenv.rb
+++ b/lib/mina/rbenv.rb
@@ -1,4 +1,3 @@
-# Makes mina work alot better with rbenv
 settings.bash_profile ||= '~/.bash_profile'
 
 namespace :rbenv do  
@@ -11,10 +10,11 @@ end
 
 module Mina
     module Helpers
-        def rbenv_loaded
-            true
-        end
-        
+        # Places the commands required to load rbenv at the start of the deploy queue
+        #
+        # There is no need to use this function anywhere in your code, 
+        # it is already in place in Mina::Helpers#ssh which is the only place
+        # it needs to be.
         def load_rbenv(cmd)
             [ "echo \"-----> Loading rbenv\"",
                 echo_cmd("source #{bash_profile}"),


### PR DESCRIPTION
tl;dr Makes life much easier for those of us using rbenv.

The problem was that ~/.bash_profile wasn't being pulled in which required the use of `bundle_bin` to get bundler to work and in some cases even resulted in the ruby command not being found, which was the case on a new production server I've had to setup up.

This change causes `source ~/.bash_profile` to be added as the first command run in the ssh session which results in:

```
$ mina deploy --verbose

-----> Loading rbenv
       $ source ~/.bash_profile

-----> Creating a temporary build path
       $ touch "deploy.lock"
```

It also adds a task for checking the ruby version (for debugging only):

```
invoke :'rbenv:ruby_version'
```

which appears like this in the output:

```
-----> Checking Ruby version
       $ ruby -v
       ruby 1.9.2p290 (2011-07-09 revision 32553) [x86_64-linux]
```

For rbenv users this render the need for `bundle_bin` and any other patches redundant and only needs tem to add

```
require 'mina/rbenv'
```

to the top of their `config/deploy.rb`
