### PR TITLE
Avoid errors on rake tasks when using Zsh.

### DIFF
--- a/lib/mina/rails.rb
+++ b/lib/mina/rails.rb
@@ -2,7 +2,7 @@ require 'mina/bundler'
 
 settings.rails_env ||= 'production'
 # TODO: This should be lambda
-settings.bundle_prefix ||= lambda { %{RAILS_ENV="#{rails_env}" #{bundle_bin} exec} }
+settings.bundle_prefix ||= lambda { %{RAILS_ENV="#{rails_env}" #{ENV['SHELL'] =~ /zsh/ ? 'noglob ' : ''}#{bundle_bin} exec} }
 settings.rake ||= lambda { %{#{bundle_prefix} rake} }
 settings.rails ||= lambda { %{#{bundle_prefix} rails} }
 settings.asset_paths ||= ['vendor/assets/', 'app/assets/']


### PR DESCRIPTION
[Zsh breaks rake's ability to accept arguments](http://robots.thoughtbot.com/post/18129303042/how-to-use-arguments-in-a-rake-task). You have to use noglob for them to run properly.
It may not popup into what's currently implemented now but it may happen at some stage.
