### PR TITLE
Prevent git log from using a pager

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -32,7 +32,7 @@ namespace :git do
     status = %[
       echo "-----> Using this git commit" &&
       echo &&
-      #{echo_cmd %[git log --format="%aN (%h):%n> %s" -n 1]} &&
+      #{echo_cmd %[git --no-pager log --format="%aN (%h):%n> %s" -n 1]} &&
       #{echo_cmd %[rm -rf .git]} &&
       echo
     ]


### PR DESCRIPTION
When git uses a pager you have to close it explicit to continue with the deployment
