### PR TITLE
Cleanup fails to cd releases_path

### DIFF
--- a/lib/mina/deploy.rb
+++ b/lib/mina/deploy.rb
@@ -37,8 +37,7 @@ namespace :deploy do
     All other deployed revisions are removed from the servers."
   task :cleanup do
     queue %{echo "-----> Cleaning up old releases (keeping #{keep_releases!})"}
-    queue echo_cmd %{cd "#{deploy_to!}" || exit 15}
-    queue echo_cmd %{cd "#{releases_path!}" || exit 16}
+    queue echo_cmd %{cd "#{deploy_to!}/#{releases_path!}" || exit 15}
     queue echo_cmd %{count=`ls -1d [0-9]* | sort -rn | wc -l`}
     queue echo_cmd %{remove=$((count > 5 ? count - #{keep_releases} : 0))}
     queue echo_cmd %{ls -1d [0-9]* | sort -rn | tail -n $remove | xargs rm -rf {}}


### PR DESCRIPTION
For some strange reason having cleanup cd to deploy_to and then releases_path makes the deploy fail: it can't find the releases_path directory.

```
-----> Cleaning up old releases (keeping 3)
       $ cd "/exordo-dev/instances/d0000052" || exit 15
       $ cd "releases" || exit 16
 !     ERROR: Deploy failed.
```

When cd is combined in one command it just works fine:

```
-----> Cleaning up old releases (keeping 3)
       $ cd "/exordo-dev/instances/d0000052/releases" || exit 15
       $ count=0
       $ remove=0
       $ ls -1d [0-9]* | sort -rn | tail -n  | xargs rm -rf {}

-----> Build finished
```

In this case, deploy:cleanup is called at the end of the deploy task.

Am I doing something wrong or is it a bug?
