### PR TITLE
Added health check task

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -1,6 +1,7 @@
 require 'mina/bundler'
 require 'mina/rails'
 require 'mina/git'
+require 'mina/health'
 # require 'mina/rbenv'  # for rbenv support. (http://rbenv.org)
 # require 'mina/rvm'    # for rvm support. (http://rvm.io)
 
@@ -48,6 +49,8 @@ task :deploy => :environment do
     to :launch do
       queue 'touch tmp/restart.txt'
     end
+
+    invoke :health
   end
 end
 

--- a/lib/mina/health.rb
+++ b/lib/mina/health.rb
@@ -1,0 +1,7 @@
+desc "Try access the deployed domain for health check and undo last deploy if has a problem"
+task :health do
+  queue %[
+        echo "-----> Health Checking... (http://#{domain})"
+        curl -fs http://#{domain} > /dev/null
+      ]
+end


### PR DESCRIPTION
Hi, I miss this feature in every project that I has a deploy recipe. Couse sometimes we do a bad deploy and everything come down. This task do a simple request for http://domain using curl, and return error (undo all deploy) if get 500 (or any http error code).

I hope that this can useful for everyone.
