### PR TITLE
Rewrote deploy:cleanup task to put it all in the same queue.

### DIFF
--- a/lib/mina/deploy.rb
+++ b/lib/mina/deploy.rb
@@ -36,11 +36,13 @@ namespace :deploy do
     each server (though you can change this with the keep_releases setting).
     All other deployed revisions are removed from the servers."
   task :cleanup do
-    queue %{echo "-----> Cleaning up old releases (keeping #{keep_releases!})"}
-    queue echo_cmd %{cd "#{deploy_to!}/#{releases_path!}" || exit 15}
-    queue echo_cmd %{count=`ls -1d [0-9]* | sort -rn | wc -l`}
-    queue echo_cmd %{remove=$((count > 5 ? count - #{keep_releases} : 0))}
-    queue echo_cmd %{ls -1d [0-9]* | sort -rn | tail -n $remove | xargs rm -rf {}}
+    queue %{
+      echo "-----> Cleaning up old releases (keeping #{keep_releases!})"
+      #{echo_cmd %{cd "#{deploy_to!}/#{releases_path!}" || exit 15}}
+      #{echo_cmd %{count=`ls -1d [0-9]* | sort -rn | wc -l`}}
+      #{echo_cmd %{remove=$((count > 5 ? count - #{keep_releases} : 0))}}
+      #{echo_cmd %{ls -1d [0-9]* | sort -rn | tail -n $remove | xargs rm -rf {}}}
+    }
   end
 end
 


### PR DESCRIPTION
This allows you to call the task from a deploy block, let's say at the
end.

The task runs just fine when run alone because the queued commands
aren't encapsulated in a block. On deploy, each of them is isolated,
therefore the vars aren't shared and it fails to use them.

Quick bash example:

```
(f='test' && echo $f) && (z=$f && echo $f && echo $z)
```

will print 'test' and two empty lines because $f isn't there on the
second block making $z blank too.

unscoping it prints 'test' three times as expected:

```
f='test' && echo $f && z=$f && echo $f && echo $z
```
