### PR TITLE
Allow changing :term_mode for setup task

### DIFF
--- a/lib/mina/deploy.rb
+++ b/lib/mina/deploy.rb
@@ -74,7 +74,7 @@ end
 
 desc "Sets up a site."
 task :setup do
-  set :term_mode, :pretty
+  set_default :term_mode, :pretty
 
   settings.deploy_to!
 


### PR DESCRIPTION
Using :pretty mode on some FreeBSD systems produces zombies, artefacts
and hung processes. This change should allow one to do something like
"mina freebsd setup".
