### PR TITLE
Fix broken pipe error after deploy

### DIFF
--- a/lib/mina/exec_helpers.rb
+++ b/lib/mina/exec_helpers.rb
@@ -29,6 +29,7 @@ module Mina
           Sys.stream_stdout(o) { |str| print_str str }
 
           Process.waitpid pid_err
+          Process.kill 'TERM', pid_in
         end
 
       status.exitstatus


### PR DESCRIPTION
I'm getting this error right after `mina deploy` if I press any button in my shell (tried both zsh and bash).

```
/home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/output_helpers.rb:113:in `write': Broken pipe (Errno::EPIPE)
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/output_helpers.rb:113:in `putc'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/output_helpers.rb:113:in `block (2 levels) in pretty_system'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/output_helpers.rb:108:in `fork'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib
/mina/output_helpers.rb:108:in `block in pretty_system'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/open4-1.3.0/lib/open4.rb:107:in `call'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/open4-1.3.0/lib/open4.rb:107:in `do_popen'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/open4-1.3.0/lib/open4.rb:30:in `popen4'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/tools.rb:11:in `popen4'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/output_helpers.rb:83:in `pretty_system'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/ssh_helpers.rb:43:in `ssh'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/helpers.rb:49:in `block in run!'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/helpers.rb:76:in `measure'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/helpers.rb:65:in `report_time'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/helpers.rb:49:in `run!'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/lib/mina/helpers.rb:86:in `mina_cleanup!'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/bin/mina:55:in `block (2 levels) in <top (required)>'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/1.9.1/rake/application.rb:133:in `standard_exception_handling'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/bin/mina:26:in `block in <top (required)>'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/bin/mina:25:in `instance_eval'
    from /home/tomas/.rbenv/versions/1.9.3-p286/lib/ruby/gems/1.9.1/gems/mina-0.2.1/bin/mina:25:in `<top (required)>'
    from /home/tomas/.rbenv/versions/1.9.3-p286/bin/mina:23:in `load'
    from /home/tomas/.rbenv/versions/1.9.3-p286/bin/mina:23:in `<main>'
```

The problem is in the subprocess that listens for standard input. Once the ssh session is over the process lingers waiting for that one character to still be entered because of [this](https://github.com/tomasv/mina/blob/master/lib/mina/exec_helpers.rb#L84). The connection is already closed so the write causes this error to pop up.

My attempt at a fix terminates the stdin subprocess right after the stderr subprocess exits. I'm not sure whether that's the most elegant way of handling it, but it works for me.
