### PR TITLE
Add :reenable option to Mina::Helper#invoke

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -10,9 +10,14 @@ module Mina
     #
     #     invoke :'git:clone'
     #     invoke :restart
+    #
+    # Options:
+    #   reenable (bool) - Execute the task even next time.
+    #
 
-    def invoke(task)
+    def invoke(task, options = {})
       Rake.application.invoke_task task
+      Rake::Task[task].reenable if options[:reenable]
     end
 
     # ### erb

--- a/spec/dsl/invoke_spec.rb
+++ b/spec/dsl/invoke_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'Mina' do
+  it '#invoke should work' do
+
+    rake {
+      task :clone do
+        queue 'git clone'
+      end
+    }
+
+    2.times {
+      rake { invoke :clone }
+    }
+
+    rake.commands.should == ['git clone']
+  end
+
+  it '#invoke should work with :reenable option' do
+
+    rake {
+      task :pull do
+        queue 'git pull'
+      end
+    }
+
+    2.times {
+      rake { invoke :pull, reenable: true }
+    }
+
+    rake.commands.should == ['git pull', 'git pull']
+  end
+end


### PR DESCRIPTION
I've added the "reenable" option to "invoke" method that can be used to execute the task repeatedly.
For example, I think you can use this when you want to deploy to multiple servers.
