### PR TITLE
Foreman integration

### DIFF
--- a/lib/mina/foreman.rb
+++ b/lib/mina/foreman.rb
@@ -11,18 +11,18 @@
 #
 #    set :application, "app-name"
 #
-#      task :deploy => :environment do
-#        deploy do
-#          # ...
-#          invoke 'foreman:export'
-#          # ...
-#        end
+#    task :deploy => :environment do
+#      deploy do
+#        # ...
+#        invoke 'foreman:export'
+#        # ...
+#      end
 #
-#        to :launch do
-#          invoke 'foreman:restart'
-#        end
+#      to :launch do
+#        invoke 'foreman:restart'
 #      end
 #    end
+#
 
 # ## Settings
 # Any and all of these settings can be overriden in your `deploy.rb`.


### PR DESCRIPTION
This PR adds support for [foreman](http://blog.daviddollar.org/2011/05/06/introducing-foreman.html). Foreman is very useful for running application services. 

I provided a separate `foreman` plugin namespace with examples. Integration is very simple and straight-forward. The only thing that this plugin depends  on is `application` variable, that i believe is not being defined in mina config. 

All tasks were tested on real application with mina 0.2.1
