### PR TITLE
Clone as non-bare repository to cache submodules (performance up)

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -35,15 +35,17 @@ namespace :git do
       ]
     else
       %{
-        if [ ! -d "#{deploy_to}/scm/objects" ]; then
+        if [ ! -d "#{deploy_to}/scm" ]; then
           echo "-----> Cloning the Git repository"
-          #{echo_cmd %[git clone "#{repository!}" "#{deploy_to}/scm" --bare]}
+          #{echo_cmd %[git clone "#{repository!}" "#{deploy_to}/scm" --recursive && (cd "#{deploy_to}/scm" && git checkout -b deploy #{branch})]}
         else
           echo "-----> Fetching new git commits"
-          #{echo_cmd %[(cd "#{deploy_to}/scm" && git fetch "#{repository!}" "#{branch}:#{branch}" --force)]}
+          #{echo_cmd %[(cd "#{deploy_to}/scm" && git fetch "#{repository!}" "#{branch}:#{branch}" --force && git reset --hard #{branch})]}
         fi &&
-        echo "-----> Using git branch '#{branch}'" &&
-        #{echo_cmd %[git clone "#{deploy_to}/scm" . --recursive --branch "#{branch}"]} &&
+        echo "-----> Updating git submodules" &&
+        #{echo_cmd %[(cd "#{deploy_to}/scm" && git submodule init && git submodule sync && git submodule update --init --recursive)]} &&
+        echo "-----> Copying to release path (branch: '#{branch}')" &&
+        #{echo_cmd %[rsync -lrpt "#{deploy_to}/scm/" .]} &&
       }
     end
 


### PR DESCRIPTION
I tried Mina in my project including big submodule (WordPress).
But it takes too much time to clone submodules every deployment.
So I propose that it keeps non-bare repository with submodules like Capistrano's remote-cache.

referred to: https://github.com/capistrano/capistrano/blob/master/lib/capistrano/recipes/deploy/scm/git.rb
