### PR TITLE
Full path to tmp/restart.txt

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -60,7 +60,7 @@ task :deploy => :environment do
     invoke :'rails:assets_precompile'
 
     to :launch do
-      queue 'touch tmp/restart.txt'
+      queue "touch #{deploy_to}/tmp/restart.txt"
     end
   end
 end


### PR DESCRIPTION
Example deploy.rb copied by mina init contains 'touch tmp/restart.txt' which is not working:

```
-----> Launching
       touch: cannot touch `tmp/restart.txt': No such file or directory
 !     ERROR: Deploy failed.
```

This fixes it using full path.
