### PR TITLE
Make mina work with system-wide rbenv

### DIFF
--- a/lib/mina/rbenv.rb
+++ b/lib/mina/rbenv.rb
@@ -41,6 +41,7 @@ task :'rbenv:load' do
       exit 1
     fi
 
-    #{echo_cmd %{eval "$(rbenv init -)"}}
+    #{echo_cmd %{export PATH="#{rbenv_path}/shims:$PATH"}}
+    #{echo_cmd %{export RBENV_ROOT="#{rbenv_path}"}}
   }
 end


### PR DESCRIPTION
For production servers it's handy to install rbenv system-wide as described in https://github.com/sstephenson/rbenv/wiki/shared-install-of-rbenv
This PR adds support for such use cases and removes a bit of shell magic (rbenv init).
