### PR TITLE
Added '--create' to rvm:use and a new task to create rvm wrappers

### DIFF
--- a/lib/mina/rvm.rb
+++ b/lib/mina/rvm.rb
@@ -58,7 +58,7 @@ task :'rvm:use', :env do |t, args|
 end
 
 
-# ### rvm:use[]
+# ### rvm:wrapper[]
 # Creates a rvm wrapper for a given executable
 #
 # This is usually placed in the `:setup` task.


### PR DESCRIPTION
- Added --create to the rvm:use task. This way you don't need to previously create the gemset before deploying a new application;
- Added a new task to create rvm wrappers: rvm:wrapper[env,name,binary]
