### PR TITLE
Fix --verbose option to work

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -311,13 +311,7 @@ module Mina
     # Returns true or false.
 
     def verbose_mode?
-      if Rake.respond_to?(:verbose)
-        # Rake 0.9.x
-        Rake.verbose == true
-      else
-        # Rake 0.8.x
-        RakeFileUtils.verbose_flag != :default
-      end
+      RakeFileUtils.verbose_flag != :default
     end
 
     # ### simulate_mode?


### PR DESCRIPTION
mina -v option works, but --verbose option did not work. 

I verified this code works with the latest version of rake (v10.0.3) and v0.9.2. 
