### PR TITLE
Incorrect exit status if deploy fails

### DIFF
--- a/bin/mina
+++ b/bin/mina
@@ -58,7 +58,7 @@ Rake.application.instance_eval do
       puts ""
       scope.print_error "Command failed."
       scope.print_stderr "#{e.message}"
-      exit e.exitstatus
+      exit(e.exitstatus > 255 ? e.exitstatus >> 8 : e.exit_status)
     end
   end
 end


### PR DESCRIPTION
1. If exit status is greater than 255, it returned as 0 (success)
2. Process::Status.to_i returns status shifted left by 8 ([Documentation](http://rubydoc.info/stdlib/core/Process/Status))

As result if deployment script fails, mina returns success status (and build not fails)

It's fix for this problem.
