### PR TITLE
Fix "can't modify frozen String" occurred in #ssh_command

### DIFF
--- a/lib/mina/ssh_helpers.rb
+++ b/lib/mina/ssh_helpers.rb
@@ -47,7 +47,7 @@ module Mina
     #     #=> 'ssh diggity@foo.com'
 
     def ssh_command
-      args = domain!
+      args = domain!.dup
       args = "#{user}@#{args}" if user?
       args << " -i #{identity_file}" if identity_file?
       args << " -p #{port}" if port?


### PR DESCRIPTION
When I set :domain like

```
set :domain, ENV['HOST']
```

I saw the following error. This patch fixes this error. 

```
can't modify frozen String
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/ssh_helpers.rb:55:in `ssh_command'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/ssh_helpers.rb:32:in `ssh'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/helpers.rb:54:in `block in run!'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/helpers.rb:81:in `measure'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/helpers.rb:70:in `report_time'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/helpers.rb:54:in `run!'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/lib/mina/helpers.rb:91:in `mina_cleanup!'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/bin/mina:55:in `block (2 levels) in <top (required)>'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/rake-10.0.3/lib/rake/application.rb:160:in `standard_exception_handling'   
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/bin/mina:26:in `block in <top (required)>'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/bin/mina:25:in `instance_eval'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/mina-6939c3e4cf13/bin/mina:25:in `<top (required)>'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bin/mina:23:in `load'
/home/seo.naotoshi/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bin/mina:23:in `<main>'
```

I wanted to add a test for this, but sorry, I could not find any tests for #ssh_command. I could not add it. 
