### PR TITLE
Fix keep_releases bug 

### DIFF
--- a/lib/mina/deploy.rb
+++ b/lib/mina/deploy.rb
@@ -65,7 +65,7 @@ namespace :deploy do
       echo "-----> Cleaning up old releases (keeping #{keep_releases!})"
       #{echo_cmd %{cd "#{deploy_to!}/#{releases_path!}" || exit 15}}
       #{echo_cmd %{count=`ls -1d [0-9]* | sort -rn | wc -l`}}
-      #{echo_cmd %{remove=$((count > 5 ? count - #{keep_releases} : 0))}}
+      #{echo_cmd %{remove=$(($count > #{keep_releases} ? count - #{keep_releases} : 0))}}
       #{echo_cmd %{ls -1d [0-9]* | sort -rn | tail -n $remove | xargs rm -rf {}}}
     }
   end


### PR DESCRIPTION
:keep_releases value is not honoured by Mina because  task :cleanup is ignoring it on purposes (there is an hard-coded value of 5 which should not be in the first instance); attached there is a proper fix that let the user specify the number of releases that Mina must keep on.
