### PR TITLE
Create all the shared paths defined on the setup step

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -16,8 +16,10 @@ set :repository, 'git://...'
 set :branch, 'master'
 
 # Manually create these paths in shared/ (eg: shared/config/database.yml) in your server.
-# They will be linked in the 'deploy:link_shared_paths' step.
-set :shared_paths, ['config/database.yml', 'log']
+# They will be created in the 'setup' step and linked in the 'deploy:link_shared_paths' step.
+set :shared_dirs,  ['log']
+set :shared_files, ['config/database.yml']
+set :shared_paths, shared_dirs + shared_files
 
 # Optional settings:
 #   set :user, 'foobar'    # Username in the server to SSH to.
@@ -38,14 +40,6 @@ end
 # For Rails apps, we'll make some of the shared paths that are shared between
 # all releases.
 task :setup => :environment do
-  queue! %[mkdir -p "#{deploy_to}/shared/log"]
-  queue! %[chmod g+rx,u+rwx "#{deploy_to}/shared/log"]
-
-  queue! %[mkdir -p "#{deploy_to}/shared/config"]
-  queue! %[chmod g+rx,u+rwx "#{deploy_to}/shared/config"]
-
-  queue! %[touch "#{deploy_to}/shared/config/database.yml"]
-  queue  %[echo "-----> Be sure to edit '#{deploy_to}/shared/config/database.yml'."]
 end
 
 desc "Deploys the current version to the server."
@@ -53,11 +47,11 @@ task :deploy => :environment do
   deploy do
     # Put things that will set up an empty directory into a fully set-up
     # instance of your project.
-    invoke :'git:clone'
-    invoke :'deploy:link_shared_paths'
-    invoke :'bundle:install'
-    invoke :'rails:db_migrate'
-    invoke :'rails:assets_precompile'
+    invoke 'git:clone'
+    invoke 'deploy:link_shared_paths'
+    invoke 'bundle:install'
+    invoke 'rails:db_migrate'
+    invoke 'rails:assets_precompile'
 
     to :launch do
       queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"

--- a/spec/commands/real_deploy_spec.rb
+++ b/spec/commands/real_deploy_spec.rb
@@ -27,6 +27,12 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
     File.exists?('deploy/last_version').should be_false
     File.exists?('deploy/deploy.lock').should be_false
 
+    # Shared paths
+    File.directory?('deploy/shared/config').should be_true
+    File.exists?('deploy/shared/config/database.yml').should be_true
+    File.directory?('deploy/shared/log').should be_true
+    File.directory?('deploy/shared/tmp/pids').should be_true
+
     print "[deploy 1]" if ENV['verbose']
     mina 'deploy', '--verbose'
     stdout.should include "-----> Creating a temporary build path"

--- a/test_env/config/deploy.rb
+++ b/test_env/config/deploy.rb
@@ -23,7 +23,9 @@ require 'mina/git'
 set :domain, 'localhost'
 set :deploy_to, "#{Dir.pwd}/deploy"
 set :repository, "#{Mina.root_path}"
-set :shared_paths, ['config/database.yml']
+set :shared_dirs,  ['log', 'tmp/pids']
+set :shared_files, ['config/database.yml']
+set :shared_paths, shared_dirs + shared_files
 
 set :keep_releases, 2
 


### PR DESCRIPTION
Hi guys,
I've made a few changes to the setup step so it will pick up the shared paths defined and will create directory structure for them automatically.
I had to separate the `shared_dirs` and `shared_files` since I don't know how to check if it's a file or dir by the string (because directories can contain dots in name and files can be with no extension)
Also I'm not quite sure about the placement of `queue_mkdir` method I defined.