### PR TITLE
Use `set -e` to fail fast

### DIFF
--- a/data/deploy.sh.erb
+++ b/data/deploy.sh.erb
@@ -5,6 +5,9 @@
 %>
 #!/usr/bin/env bash
 
+# Bail out ASAP
+set -e
+
 # Go to the deploy path
 cd "<%= deploy_to %>" || (
   echo "! ERROR: not set up."


### PR DESCRIPTION
Hi, I just got started to use mina today. And I noticed that even if some command when deploying exits with a non-zero status, the following commands would still execute. I really don't want that to happen since I simply don't want to know what would happen in that situation.

This patch makes use of bash's `-e` option and bail out asap if any command goes bad. Jenkins CI uses this. And I think deploying scripts are even more critical than CI scripts.

Hope it gets merged :)