### PR TITLE
Export RBENV_ROOT using rbenv_path

### DIFF
--- a/lib/mina/rbenv.rb
+++ b/lib/mina/rbenv.rb
@@ -33,7 +33,8 @@ set_default :rbenv_path, "$HOME/.rbenv"
 task :'rbenv:load' do
   queue %{
     echo "-----> Loading rbenv"
-    #{echo_cmd %{export PATH="#{rbenv_path}/bin:$PATH"}}
+    #{echo_cmd %{export RBENV_ROOT="#{rbenv_path}"}}
+    #{echo_cmd %{export PATH="$RBENV_ROOT/bin:$PATH"}}
 
     if ! which rbenv >/dev/null; then
       echo "! rbenv not found"


### PR DESCRIPTION
Before setting PATH with rbenv_path value, first export it as
RBENV_ROOT variable.

This is done in order to support system-wide installations of
rbenv.

This solves reported issue #106
