### PR TITLE
Bundler: Allow configuration of groups to be skipped during installation

### DIFF
--- a/lib/mina/bundler.rb
+++ b/lib/mina/bundler.rb
@@ -19,10 +19,15 @@ set_default :bundle_bin, 'bundle'
 
 set_default :bundle_path, './vendor/bundle'
 
+# ### bundle_withouts
+# Sets the colon-separated list of groups to be skipped from installation.
+
+set_default :bundle_withouts, 'development:test'
+
 # ### bundle_options
 # Sets the options for installing gems via Bundler.
 
-set_default :bundle_options, lambda { %{--without development:test --path "#{bundle_path}" --binstubs bin/ --deployment} }
+set_default :bundle_options, lambda { %{--without #{bundle_withouts} --path "#{bundle_path}" --binstubs bin/ --deployment} }
 
 # ## Deploy tasks
 # These tasks are meant to be invoked inside deploy scripts, not invoked on


### PR DESCRIPTION
Current setting only skipped development and test environment, but
depending on your setup, that might not be flexible enough to
exclude groups like ci/travis or similar.

Having this as an option (bundle_withouts) gives you the freedom
to set that to other environments, like 'development:test:staging'
or 'production' if you're deploying to a CI environment for
example.
