### PR TITLE
Added `mina ssh` command to connect to server

### DIFF
--- a/lib/mina/default.rb
+++ b/lib/mina/default.rb
@@ -142,3 +142,13 @@ desc "Show all tasks."
 task :tasks do
   show_task_help :full => true
 end
+
+# ### ssh
+# Connects to the server via ssh
+#
+#     $ mina ssh
+
+desc "Open an ssh session to the server"
+task :ssh do
+  exec ssh_command
+end


### PR DESCRIPTION
As `mina console` simplifies opening a Rails console on server, `mina ssh` can simplify connecting to server itself, without need to remember user and server address.