### PR TITLE
Fix copy command for assets

### DIFF
--- a/lib/mina/rails.rb
+++ b/lib/mina/rails.rb
@@ -190,7 +190,7 @@ namespace :rails do
         :at => [*asset_paths],
         :skip => %[
           echo "-----> Skipping asset precompilation"
-          #{echo_cmd %[cp -R "#{deploy_to}/#{current_path}/public/assets" "./public/assets"]}
+          #{echo_cmd %[cp -R #{deploy_to}/#{current_path}/public/assets ./public/]}
         ],
         :changed => %[
           echo "-----> #{message}"


### PR DESCRIPTION
The previous cp command resulted in an extra 'assets' directory in the build_path:

```
build_path
 |- public/
     |- assets/
         |- assets/
```
