### PR TITLE
Adding support for server environment variables in deploy.rb, (:env_vars)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -648,6 +648,9 @@ The local path to the SSH private key file.
 ### ssh_options
 Switches to be passed to the `ssh` command.
 
+### env_vars
+Environment variables passed to the `ssh` command (e.g. "foo=bar baz=1").
+
 ## Tasks
 Any and all of these settings can be overriden in your `deploy.rb`.
 

--- a/lib/mina/default.rb
+++ b/lib/mina/default.rb
@@ -23,6 +23,9 @@
 # ### ssh_options
 # Switches to be passed to the `ssh` command.
 
+# ### env_vars
+# Environment variables to be passed to `ssh` command.
+
 # ## Tasks
 # Any and all of these settings can be overriden in your `deploy.rb`.
 

--- a/lib/mina/ssh_helpers.rb
+++ b/lib/mina/ssh_helpers.rb
@@ -52,7 +52,8 @@ module Mina
       args << " -i #{identity_file}" if identity_file?
       args << " -p #{port}" if port?
       args << " -A" if forward_agent?
-      args << " #{ssh_options}"  if ssh_options?
+      args << " #{ssh_options}" if ssh_options?
+      args << " export #{env_vars}" if env_vars?
       args << " -t"
       "ssh #{args}"
     end


### PR DESCRIPTION
Users may specify environment variables, as a string, to be passed to the ssh commands.  

Idea: Our app is ported from a heroku environment.  To use nina effectively, in the 12-factor-app paradigm, we need to be able to pass values at deploy time.

```ruby
# deploy.rb

set :env_vars, "foo=1 bar=baz"

# .env stores key-value pairs
set :env_vars, { File.open(".env").readlines.map(&:chomp).join(" ") }
````