### PR TITLE
Check db/migrate/ instead of schema.rb

### DIFF
--- a/lib/mina/rails.rb
+++ b/lib/mina/rails.rb
@@ -141,10 +141,10 @@ namespace :rails do
         'Migrating database'
 
       queue check_for_changes_script \
-        :check => 'db/schema.rb',
-        :at => ['db/schema.rb'],
+        :check => 'db/migrate/',
+        :at => ['db/migrate/'],
         :skip => %[
-          echo "-----> DB schema unchanged; skipping DB migration"
+          echo "-----> DB migrations unchanged; skipping DB migration"
         ],
         :changed => %[
           echo "-----> #{message}"


### PR DESCRIPTION
This seems to me the correct way to check for migrations: diff the db/migrate/ folders.

It avoids the problems with schema_format :sql entirely. No need to try and read the schema_format setting or check either/or schema.rb/structure.sql. Fixes #57, #59 and #74.
