### PR TITLE
Allow for a build step

### DIFF
--- a/data/deploy.sh.erb
+++ b/data/deploy.sh.erb
@@ -1,5 +1,6 @@
 <%
   prepare = commands(:default).map { |s| "(\n\n#{indent 2, s}\n\n)" }.join(" && ")
+  build   = commands(:build).map   { |s| "(\n\n#{indent 2, s}\n\n)" }.join(" && ")
   launch  = commands(:launch).map  { |s| "(\n\n#{indent 2, s}\n\n)" }.join(" && ")
   clean   = commands(:clean).map   { |s| "(\n\n#{indent 2, s}\n\n)" }.join(" && ")
 %>
@@ -49,16 +50,29 @@ fi
   <%= echo_cmd %[cd "$build_path"] %> &&
   (
 <%= indent 4, (prepare.empty? ? "true" : prepare) %>
-  )
+  ) &&
+  echo "-----> Deploy finished"
 ) &&
 
 #
-# Rename to the real release path, then symlink 'current'
+# Build
 (
-  echo "-----> Build finished"
+  echo "-----> Building"
   echo "-----> Moving build to $release_path"
   <%= echo_cmd %[mv "$build_path" "$release_path"] %> &&
+  <%= echo_cmd %[cd "$release_path"] %> &&
+  (
+<%= indent 4, (build.empty? ? "true" : build) %>
+  ) &&
+  echo "-----> Build finished"
 
+) &&
+
+#
+# Launching
+# Rename to the real release path, then symlink 'current'
+(
+  echo "-----> Launching"
   echo "-----> Updating the <%= current_path %> symlink" &&
   <%= echo_cmd %[ln -nfs "$release_path" "#{current_path}"] %>
 ) &&

--- a/spec/commands/deploy_spec.rb
+++ b/spec/commands/deploy_spec.rb
@@ -29,6 +29,10 @@ describe "Invoking the 'mina' command in a project" do
       stdout.should include "bundle exec rake db:migrate"
     end
 
+    it "should include 'to :build' directives" do
+      stdout.should include "touch build.txt"
+    end
+
     it "should include 'to :launch' directives" do
       stdout.should include "touch tmp/restart.txt"
     end

--- a/spec/commands/real_deploy_spec.rb
+++ b/spec/commands/real_deploy_spec.rb
@@ -40,6 +40,7 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
     File.directory?('deploy/releases/2').should be_false
     File.exists?('deploy/current').should be_true
     File.read('deploy/last_version').strip.should == '1'
+    File.exists?('deploy/current/build.txt').should be_true
     File.exists?('deploy/current/tmp/restart.txt').should be_true
 
     # And again, to test out sequential versions and stuff

--- a/test_env/config/deploy.rb
+++ b/test_env/config/deploy.rb
@@ -42,6 +42,9 @@ task :deploy => :environment do
     invoke :'bundle:install'
     invoke :'rails:db_migrate'
 
+    to :build do
+      queue "touch build.txt"
+    end
     to :launch do
       invoke :'passenger:restart'
     end


### PR DESCRIPTION
Add a ':build' step that can be executed after the deployment has been
done and the code moved to its final destination but before the sysmlink
for the current release has been updated (aka new code is live).
This allows for build steps that require code to be in its final
destination (i.e. some autoloaders resolve full paths, moving the code
after the autoloader has done its setup work breaks the code).