### PR TITLE
Parse task string to reenable task

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -17,7 +17,10 @@ module Mina
 
     def invoke(task, options = {})
       Rake.application.invoke_task task
-      Rake::Task[task].reenable if options[:reenable]
+      if options[:reenable]
+        name = Rake.application.parse_task_string(task).first
+        Rake::Task[name].reenable
+      end
     end
 
     # ### erb

--- a/spec/dsl/invoke_spec.rb
+++ b/spec/dsl/invoke_spec.rb
@@ -30,4 +30,19 @@ describe 'Mina' do
 
     rake.commands.should == ['git pull', 'git pull']
   end
+
+  it '#invoke with task arguments should work with :reenable option' do
+
+    rake {
+      task :hello, [:world] do |t, args|
+        queue "echo Hello #{args[:world]}"
+      end
+    }
+
+    %w(World Pirate).each { |name|
+      rake { invoke :"hello[#{name}]", :reenable => true }
+    }
+
+    rake.commands.should == ['echo Hello World', 'echo Hello Pirate']
+  end
 end


### PR DESCRIPTION
I noticed that when using the `invoke` helper and the reenable option with a task with arguments it fails to lookup the task.

I added a failing test and used the `parse_task_string` method to get the task name without the arguments in order to reenable the task.
