### PR TITLE
Convert specs to RSpec expect syntax with transpec

### DIFF
--- a/spec/command_helper.rb
+++ b/spec/command_helper.rb
@@ -36,7 +36,7 @@ def mina(*args)
     puts stderr
   end
 
-  exitstatus.should == 0
+  expect(exitstatus).to eq(0)
 end
 
 def stdout

--- a/spec/commands/cleanup_spec.rb
+++ b/spec/commands/cleanup_spec.rb
@@ -11,6 +11,6 @@ describe "Invoking the 'mina deploy:cleanup' command" do
 
     mina 'deploy:cleanup'
 
-    Dir["deploy/releases/*"].length.should == 2
+    expect(Dir["deploy/releases/*"].length).to eq(2)
   end
 end

--- a/spec/commands/command_spec.rb
+++ b/spec/commands/command_spec.rb
@@ -8,24 +8,24 @@ describe "Invoking the 'mina' command in a project" do
 
   it "should think it's 'mina', not 'rake' (1)" do
     run_command 'pinkledills'
-    exitstatus.should_not == 0
-    stderr.should include 'mina aborted'
+    expect(exitstatus).not_to eq(0)
+    expect(stderr).to include 'mina aborted'
   end
 
   it "should think it's 'mina', not 'rake' (1)" do
     mina '-T'
-    stdout.should include 'mina help'
-    stdout.should include 'mina git:clone'
+    expect(stdout).to include 'mina help'
+    expect(stdout).to include 'mina git:clone'
   end
 
   it 'with --version should print the version' do
     mina '--version'
-    stdout.should include Mina.version
+    expect(stdout).to include Mina.version
   end
 
   it 'with -V should print the version' do
     mina '-V'
-    stdout.should include Mina.version
+    expect(stdout).to include Mina.version
   end
 
   describe 'without arguments' do
@@ -35,37 +35,37 @@ describe "Invoking the 'mina' command in a project" do
 
     it 'should print standard help tasks' do
       mina
-      stdout.should include 'mina help'
-      stdout.should include 'mina init'
-      stdout.should include 'mina tasks'
+      expect(stdout).to include 'mina help'
+      expect(stdout).to include 'mina init'
+      expect(stdout).to include 'mina tasks'
     end
 
     it 'should print project-specific tasks' do
       mina
-      stdout.should include 'mina deploy'
-      stdout.should include 'mina restart'
-      stdout.should include 'mina setup'
+      expect(stdout).to include 'mina deploy'
+      expect(stdout).to include 'mina restart'
+      expect(stdout).to include 'mina setup'
     end
 
     it "should be the same as running 'help'" do
       previous_out = stdout
 
       mina 'help'
-      stdout.should == previous_out
+      expect(stdout).to eq(previous_out)
     end
   end
 
   it "with 'mina -f' on a non-existing file should fail" do
     run_command '-f', 'foobar'
-    stderr.should include 'mina aborted'
-    stderr.should include 'No Rakefile found'
+    expect(stderr).to include 'mina aborted'
+    expect(stderr).to include 'No Rakefile found'
   end
 
   it "with 'mina tasks' should print tasks" do
     mina 'tasks'
 
-    stdout.should include('bundle:install')
-    stdout.should include('Install gem dependencies using Bundler')
-    stdout.should include('passenger:restart')
+    expect(stdout).to include('bundle:install')
+    expect(stdout).to include('Install gem dependencies using Bundler')
+    expect(stdout).to include('passenger:restart')
   end
 end

--- a/spec/commands/custom_config_spec.rb
+++ b/spec/commands/custom_config_spec.rb
@@ -9,12 +9,12 @@ describe "Invoking the 'mina' command in a project without a deploy.rb" do
 
   it 'should fail' do
     run_command 'deploy', '--simulate'
-    exitstatus.should be > 0
+    expect(exitstatus).to be > 0
   end
 
   it 'should pass if you provide a new rakefile' do
     mina 'deploy', '--simulate', '-f', 'custom_deploy.rb'
-    stdout.should include 'Creating a temporary build path'
+    expect(stdout).to include 'Creating a temporary build path'
   end
 end
 

--- a/spec/commands/deploy_spec.rb
+++ b/spec/commands/deploy_spec.rb
@@ -12,25 +12,25 @@ describe "Invoking the 'mina' command in a project" do
     end
 
     it "should take care of the lockfile" do
-      stdout.should =~ /ERROR: another deployment is ongoing/
-      stdout.should =~ /touch ".*deploy\.lock"/
-      stdout.should =~ /rm -f ".*deploy\.lock"/
+      expect(stdout).to match(/ERROR: another deployment is ongoing/)
+      expect(stdout).to match(/touch ".*deploy\.lock"/)
+      expect(stdout).to match(/rm -f ".*deploy\.lock"/)
     end
 
     it "should honor releases_path" do
-      stdout.should include "releases/"
+      expect(stdout).to include "releases/"
     end
 
     it "should symlink the current_path" do
-      stdout.should =~ /ln .*current/
+      expect(stdout).to match(/ln .*current/)
     end
 
     it "should include deploy directives" do
-      stdout.should include "bundle exec rake db:migrate"
+      expect(stdout).to include "bundle exec rake db:migrate"
     end
 
     it "should include 'to :launch' directives" do
-      stdout.should include "touch tmp/restart.txt"
+      expect(stdout).to include "touch tmp/restart.txt"
     end
   end
 end

--- a/spec/commands/outside_project_spec.rb
+++ b/spec/commands/outside_project_spec.rb
@@ -12,22 +12,22 @@ describe "Invoking the 'mina' command outside a project" do
     end
 
     it 'should print standard help tasks' do
-      stdout.should include('mina help')
-      stdout.should include('mina init')
-      stdout.should include('mina tasks')
+      expect(stdout).to include('mina help')
+      expect(stdout).to include('mina init')
+      expect(stdout).to include('mina tasks')
     end
 
     it "should not print project-specific tasks" do
-      stdout.should_not include('mina deploy')
-      stdout.should_not include('mina restart')
-      stdout.should_not include('mina setup')
+      expect(stdout).not_to include('mina deploy')
+      expect(stdout).not_to include('mina restart')
+      expect(stdout).not_to include('mina setup')
     end
 
     %w[-h --help].each do |arg|
       it "should have the same output as 'mina #{arg}'" do
         @previous_output = stdout
         mina arg
-        stdout.should == @previous_output
+        expect(stdout).to eq(@previous_output)
       end
     end
   end

--- a/spec/commands/real_deploy_spec.rb
+++ b/spec/commands/real_deploy_spec.rb
@@ -21,33 +21,33 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
   it 'should set up and deploy fine' do
     print "[setup]" if ENV['verbose']
     mina 'setup', '--verbose'
-    File.directory?('deploy').should be_true
-    File.directory?('deploy/releases').should be_true
-    File.directory?('deploy/shared').should be_true
-    File.exists?('deploy/last_version').should be_false
-    File.exists?('deploy/deploy.lock').should be_false
+    expect(File.directory?('deploy')).to be_true
+    expect(File.directory?('deploy/releases')).to be_true
+    expect(File.directory?('deploy/shared')).to be_true
+    expect(File.exists?('deploy/last_version')).to be_false
+    expect(File.exists?('deploy/deploy.lock')).to be_false
 
     print "[deploy 1]" if ENV['verbose']
     mina 'deploy', '--verbose'
-    stdout.should include "-----> Creating a temporary build path"
-    stdout.should include "rm -rf .git"
-    stdout.should include "mkdir -p"
-    File.exists?('deploy/last_version').should be_true
-    File.exists?('deploy/deploy.lock').should be_false
-    File.directory?('deploy/releases').should be_true
-    File.directory?('deploy/releases/1').should be_true
-    File.exists?('deploy/releases/1/README.md').should be_true
-    File.directory?('deploy/releases/2').should be_false
-    File.exists?('deploy/current').should be_true
-    File.read('deploy/last_version').strip.should == '1'
-    File.exists?('deploy/current/tmp/restart.txt').should be_true
+    expect(stdout).to include "-----> Creating a temporary build path"
+    expect(stdout).to include "rm -rf .git"
+    expect(stdout).to include "mkdir -p"
+    expect(File.exists?('deploy/last_version')).to be_true
+    expect(File.exists?('deploy/deploy.lock')).to be_false
+    expect(File.directory?('deploy/releases')).to be_true
+    expect(File.directory?('deploy/releases/1')).to be_true
+    expect(File.exists?('deploy/releases/1/README.md')).to be_true
+    expect(File.directory?('deploy/releases/2')).to be_false
+    expect(File.exists?('deploy/current')).to be_true
+    expect(File.read('deploy/last_version').strip).to eq('1')
+    expect(File.exists?('deploy/current/tmp/restart.txt')).to be_true
 
     # And again, to test out sequential versions and stuff
     print "[deploy 2]" if ENV['verbose']
     mina 'deploy'
-    stdout.should_not include "rm -rf .git"
-    stdout.should_not include "mkdir -p"
-    File.directory?('deploy/releases/2').should be_true
-    File.read('deploy/last_version').strip.should == '2'
+    expect(stdout).not_to include "rm -rf .git"
+    expect(stdout).not_to include "mkdir -p"
+    expect(File.directory?('deploy/releases/2')).to be_true
+    expect(File.read('deploy/last_version').strip).to eq('2')
   end
 end

--- a/spec/commands/verbose_spec.rb
+++ b/spec/commands/verbose_spec.rb
@@ -10,12 +10,12 @@ describe "Invoking the 'mina' command in a project" do
   it 'should echo commands in verbose mode' do
     mina 'deploy', '--verbose', '--simulate'
 
-    stdout.should include %[echo #{Shellwords.escape('$ git')}]
+    expect(stdout).to include %[echo #{Shellwords.escape('$ git')}]
   end
 
   it 'should not echo commands when not in verbose mode' do
     mina 'deploy', '--simulate'
 
-    stdout.should_not include %[echo #{Shellwords.escape('$ git')}]
+    expect(stdout).not_to include %[echo #{Shellwords.escape('$ git')}]
   end
 end

--- a/spec/dsl/invoke_spec.rb
+++ b/spec/dsl/invoke_spec.rb
@@ -13,7 +13,7 @@ describe 'Mina' do
       rake { invoke :clone }
     }
 
-    rake.commands.should == ['git clone']
+    expect(rake.commands).to eq(['git clone'])
   end
 
   it '#invoke should work with :reenable option' do
@@ -28,6 +28,6 @@ describe 'Mina' do
       rake { invoke :pull, :reenable => true }
     }
 
-    rake.commands.should == ['git pull', 'git pull']
+    expect(rake.commands).to eq(['git pull', 'git pull'])
   end
 end

--- a/spec/dsl/queue_spec.rb
+++ b/spec/dsl/queue_spec.rb
@@ -8,7 +8,7 @@ describe 'Mina' do
       end
       invoke :hello
     }
-    rake.instance_variable_get(:@hello).should == 'world'
+    expect(rake.instance_variable_get(:@hello)).to eq('world')
   end
 
   it '#queue should work' do
@@ -16,7 +16,7 @@ describe 'Mina' do
       queue 'sudo service nginx restart'
     }
 
-    rake.commands.should == ['sudo service nginx restart']
+    expect(rake.commands).to eq(['sudo service nginx restart'])
   end
 
   it '#queue should work with multiple commands' do
@@ -25,7 +25,7 @@ describe 'Mina' do
       queue 'sudo service nginx restart'
     }
 
-    rake.commands.should == ['echo Restarting', 'sudo service nginx restart']
+    expect(rake.commands).to eq(['echo Restarting', 'sudo service nginx restart'])
   end
 
   it '#queue should work inside tasks' do
@@ -44,6 +44,6 @@ describe 'Mina' do
 
     rake { invoke :restart }
 
-    rake.commands.should == ['echo Restarting', 'touch tmp/restart.txt']
+    expect(rake.commands).to eq(['echo Restarting', 'touch tmp/restart.txt'])
   end
 end

--- a/spec/dsl/settings_in_rake_spec.rb
+++ b/spec/dsl/settings_in_rake_spec.rb
@@ -4,8 +4,8 @@ describe 'Settings in rake tasks' do
   it '#set should work' do
     rake { set :domain, 'localhost' }
 
-    rake.domain.should == 'localhost'
-    rake.settings.domain.should == 'localhost'
+    expect(rake.domain).to eq('localhost')
+    expect(rake.settings.domain).to eq('localhost')
   end
 
   it '#settings ||= should work' do
@@ -14,8 +14,8 @@ describe 'Settings in rake tasks' do
       settings.version ||= '3'
     }
 
-    rake.settings.version.should == '2'
-    rake.version.should == '2'
+    expect(rake.settings.version).to eq('2')
+    expect(rake.version).to eq('2')
   end
 
   it '#settings with lambdas should work' do
@@ -24,8 +24,8 @@ describe 'Settings in rake tasks' do
       set :path, lambda { "/var/www/#{version}" }
     }
 
-    rake.path.should == "/var/www/42"
-    rake.path?.should be_true
+    expect(rake.path).to eq("/var/www/42")
+    expect(rake.path?).to be_true
   end
 
   it '#settings with a bang should work' do

--- a/spec/dsl/settings_spec.rb
+++ b/spec/dsl/settings_spec.rb
@@ -8,38 +8,38 @@ describe 'Settings' do
 
     it 'setting/getting should work' do
       @settings.domain = '192.168.1.1'
-      @settings.domain.should == '192.168.1.1'
+      expect(@settings.domain).to eq('192.168.1.1')
     end
 
     it 'question mark should work' do
       @settings.deploy_to = '/var/www/there'
-      @settings.deploy_to?.should be_true
-      @settings.foobar?.should be_false
+      expect(@settings.deploy_to?).to be_true
+      expect(@settings.foobar?).to be_false
     end
 
     it 'question mark should work with nils' do
       @settings.deploy_to = nil
-      @settings.deploy_to?.should be_true
-      @settings.foobar?.should be_false
+      expect(@settings.deploy_to?).to be_true
+      expect(@settings.foobar?).to be_false
     end
 
     it '||= should work (1)' do
       @settings.x = 2
       @settings.x ||= 3
-      @settings.x.should == 2
+      expect(@settings.x).to eq(2)
     end
 
     it '||= should work (2)' do
       @settings.x ||= 3
-      @settings.x.should == 3
+      expect(@settings.x).to eq(3)
     end
 
     it 'lambdas should work' do
       @settings.path = lambda { "/var/www/#{@settings.version}" }
       @settings.version = '3'
 
-      @settings.path?.should be_true
-      @settings.path.should == "/var/www/3"
+      expect(@settings.path?).to be_true
+      expect(@settings.path).to eq("/var/www/3")
     end
 
     it 'bangs should check for settings' do
@@ -48,7 +48,7 @@ describe 'Settings' do
 
     it 'bangs should return settings' do
       @settings.version = 4
-      @settings.version!.should == 4
+      expect(@settings.version!).to eq(4)
     end
   end
 end

--- a/spec/dsl/to_spec.rb
+++ b/spec/dsl/to_spec.rb
@@ -14,7 +14,7 @@ describe 'Mina' do
 
     rake { invoke :deploy }
 
-    rake.commands.should == ['git clone']
-    rake.commands(:restart).should == ['touch tmp/restart.txt']
+    expect(rake.commands).to eq(['git clone'])
+    expect(rake.commands(:restart)).to eq(['touch tmp/restart.txt'])
   end
 end


### PR DESCRIPTION
One failing test still (though, it's a different failing test than the existing test suite).

This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 76 conversions
  from: obj.should
    to: expect(obj).to
- 25 conversions
  from: == expected
    to: eq(expected)
- 7 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 4 conversions
  from: =~ /pattern/
    to: match(/pattern/)
