### PR TITLE
add rescue for rubinius SignalException

### DIFF
--- a/lib/mina/exec_helpers.rb
+++ b/lib/mina/exec_helpers.rb
@@ -86,6 +86,8 @@ module Mina
               yield char if char
             end
           rescue Interrupt
+          # rubinius 
+          rescue SignalException
           end
         end
       end


### PR DESCRIPTION
```
An exception occurred in a forked block

    SIGTERM (SignalException)

Backtrace:

       Elapsed time: 95.00 seconds
                      { } in Rubinius::Loader#signals at kernel/loader.rb:105
                                            Proc#call at kernel/bootstrap/proc.rb:20
                                   Signal.run_handler at kernel/common/signal.rb:75
                             Rubinius.received_signal at kernel/delta/rubinius.rb:215
                  { } in IO::InternalBuffer#fill_from at kernel/common/io.rb:81
                                 Rubinius.synchronize at kernel/bootstrap/rubinius.rb:137
                         IO::InternalBuffer#fill_from at kernel/common/io.rb:73
                           IO::InternalBuffer#getbyte at kernel/common/io.rb:198
                                           IO#getbyte at kernel/common/io.rb:1601
  { } in Mina::ExecHelpers::Sys(Module)#stream_stdin! at /Users/qen/.rvm/gems/rbx-2.2.10@xxxx/gems/mina-0.3.0/lib/mina/exec_helpers.rb:85
                                         Process.fork at kernel/common/process.rb:363
                                  Kernel(Module)#fork at kernel/common/process.rb:1141
```
