### PR TITLE
fix tmp/restart.txt path

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -64,7 +64,7 @@ task :deploy => :environment do
     invoke :'rails:assets_precompile'
 
     to :launch do
-      queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"
+      queue "touch tmp/restart.txt"
     end
   end
 end


### PR DESCRIPTION
according to [readme example](https://github.com/mina-deploy/mina#deploying) which works.

This change works for me, but if I'm mistaken and naive, I'd be glad to hear what was the purpose of previous code.
