### PR TITLE
Make rails console task dependent on the environment

### DIFF
--- a/lib/mina/rails.rb
+++ b/lib/mina/rails.rb
@@ -121,7 +121,7 @@ make_run_task[:rake, 'db:migrate']
 #     $ mina console
 
 desc "Starts an interactive console."
-task :console do
+task :console => :environment do
   queue echo_cmd %[cd "#{deploy_to!}/#{current_path!}" && #{rails} console && exit]
 end
 


### PR DESCRIPTION
I'm not sure this is the right approach to solve the issue I run into it. Before executing the console task I need to load chruby (I guess using rvm or rbenv would present similar use case) and I've added the following to my `config/deploy.rb`:

```ruby
task :console => :environment do
end
```
That looks like an ugly workaround to me. Is the suggested code a good approach or is there another way to solve this problem I'm missing?

thank you for working on this project.