### PR TITLE
Add docs badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@ session per deploy, minimizing the SSH connection overhead.
     $ gem install mina
     $ mina
 
-[![Build Status](https://travis-ci.org/mina-deploy/mina.svg?branch=master)](https://travis-ci.org/mina-deploy/mina) [![Gem Version](https://badge.fury.io/rb/mina.svg)](http://badge.fury.io/rb/mina)
+[![Build Status](https://travis-ci.org/mina-deploy/mina.svg?branch=master)](https://travis-ci.org/mina-deploy/mina) [![Gem Version](https://badge.fury.io/rb/mina.svg)](http://badge.fury.io/rb/mina) [![Inline docs](http://inch-ci.org/github/mina-deploy/mina.svg?branch=master)](http://inch-ci.org/github/mina-deploy/mina)
 
 User guide
 ==========


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/mina-deploy/mina.png)](http://inch-ci.org/github/mina-deploy/mina)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/mina-deploy/mina/

Inch CI is still in its infancy, but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?

P.S. I've not seen this pattern before:

    # # Helpers: Exec helpers
    # Provides `pretty_system` which Mina uses to parse SSH output, and delegate to
    # the appropriate Output helper.
    module Mina
      module ExecHelpers

        # ### pretty_system
        # __Internal:__ A pretty version of the default `#system` commands, but
        # indents and puts color.
        #
        # Returns the exit code in integer form.
        #
        def pretty_system(code)
          [...]
        end
      end
    end

Am I right that you use a Markdown related documentation style?