### PR TITLE
Make tmp directory if it doesn't exist

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -64,6 +64,7 @@ task :deploy => :environment do
     invoke :'rails:assets_precompile'
 
     to :launch do
+      queue "mkdir -p #{deploy_to}/#{current_path}/tmp/"
       queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"
     end
   end


### PR DESCRIPTION
In mina-deploy/mina#225, gabskoro noted that the tmp folder might not
exist in all Rails projects. So, touching restart.txt won't actually do
anything.

This creates the tmp directory, in case it doesn't exist, with mkdir -p.
Unfortunately, there isn't a flag for touch which forces intermediate
directory creation, so we've got to use a separate command.
