### PR TITLE
Treat absent files as empty when changes script

### DIFF
--- a/lib/mina/rails.rb
+++ b/lib/mina/rails.rb
@@ -75,7 +75,7 @@ make_run_task = lambda { |name, sample_args|
 
 def check_for_changes_script(options={})
   diffs = options[:at].map { |path|
-    %[diff -r "#{deploy_to}/#{current_path}/#{path}" "./#{path}" 2>/dev/null]
+    %[diff -rN "#{deploy_to}/#{current_path}/#{path}" "./#{path}" 2>/dev/null]
   }.join("\n")
 
   unindent %[


### PR DESCRIPTION
Hi,

The `check_for_changes_script` method don't treat diff to new files. I try use this rake to skip rails seed created by @m3nd3s.

```ruby
desc "Seeding data to Database."
task :'db_seed' do
  seed_files = Dir['db/seeds/*.rb']
  seed_files.push("db/seeds.rb")

  queue check_for_changes_script({
    check: 'db/seeds.rb',
    at: seed_files,
    skip: %[
      echo "-----> DB seed unchanged; skipping DB seed"
    ],
    changed: %[
      echo "-----> Seeding database"
      #{echo_cmd %[#{rake} db:seed]}
    ],
    default: %[
      echo "-----> Seeding database"
      #{echo_cmd %[#{rake} db:seed]}
    ]
  })
end
```
Then, using -N param in diff command for treat absent files as empty. :smile: 