### PR TITLE
Support pretty_system on Ruby 1.8.7

### DIFF
--- a/lib/mina/exec_helpers.rb
+++ b/lib/mina/exec_helpers.rb
@@ -98,6 +98,7 @@ module Mina
 
       def stream_stdout(o, &blk)
         while str = o.getc
+          str = str.chr if str.is_a? Fixnum
           yield str
         end
       end

--- a/spec/helpers/exec_helper_spec.rb
+++ b/spec/helpers/exec_helper_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'Exec Helpers' do
+  before :each do
+    @exec = Object.new
+    @exec.send :extend, Mina::ExecHelpers
+
+    allow(@exec).to receive(:print_char)
+  end
+
+  it 'pretty_system' do
+    @exec.pretty_system "echo 'Hello there'"
+
+    expect(@exec).to have_received(:print_char).
+      with("e").with("r").with("e").with("h").with("t").
+      with(" ").
+      with("o").with("l").with("l").with("e").with("H")
+  end
+end


### PR DESCRIPTION
`IO.getc` on ruby 1.8.7 returns a `Fixnum` instead of a `String`.
