### PR TITLE
Prevent foreman export from expanding the current/ symlink

### DIFF
--- a/lib/mina/foreman.rb
+++ b/lib/mina/foreman.rb
@@ -48,7 +48,7 @@ namespace :foreman do
   desc 'Export the Procfile to Ubuntu upstart scripts'
   task :export do
     sudo_cmd = "sudo" if foreman_sudo
-    export_cmd = "#{sudo_cmd} bundle exec foreman export #{foreman_format} #{foreman_location} -a #{foreman_app} -u #{foreman_user} -l #{foreman_log}"
+    export_cmd = "#{sudo_cmd} bundle exec foreman export #{foreman_format} #{foreman_location} -a #{foreman_app} -u #{foreman_user} -d #{deploy_to!}/#{current_path!} -l #{foreman_log}"
 
     queue %{
       echo "-----> Exporting foreman procfile for #{foreman_app}"


### PR DESCRIPTION
`foreman export` will default to using `Dir.pwd` as the projects directory. Unfortunately, `Dir.pwd` automatically expands symlinks to their destinations, so `/path/to/current` becomes `/path/to/releases/N`. Instead, explicitly specify the `/path/to/current/`.
