### PR TITLE
mention  .ruby-version for rbenv comment

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -31,7 +31,7 @@ set :shared_paths, ['config/database.yml', 'log']
 # `mina deploy` or `mina rake`.
 task :environment do
   # If you're using rbenv, use this to load the rbenv environment.
-  # Be sure to commit your .rbenv-version to your repository.
+  # Be sure to commit your .ruby-version or .rbenv-version to your repository.
   # invoke :'rbenv:load'
 
   # For those using RVM, use this to load an RVM version@gemset.


### PR DESCRIPTION
according to `rbenv` Readme https://github.com/sstephenson/rbenv :

Previous versions of rbenv stored local version specifications in a file named `.rbenv-version`. For backwards compatibility, rbenv will read a local version specified in an `.rbenv-version` file, but a `.ruby-version` file in the same directory will take precedence.
