### PR TITLE
Delayed job

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -730,6 +730,25 @@ Runs a command on a server.
 $ mina run[tail -f logs.txt]
 ~~~
 
+# Modules: Delayed job
+Adds settings and tasks for background processing with with [delayed_job].
+[delayed_job]: https://rubygems.org/gems/delayed_job
+
+~~~ ruby
+require 'mina/delayed_job'
+~~~
+
+## Settings
+Any and all of these settings can be overriden in your `deploy.rb`.
+
+### delayed_job_executable
+Sets the delayed_job executable (default is Rails 4 `bin/delayed_job`)
+
+## Deploy tasks
+
+### delayed_job:restart
+Restart Delayed job
+
 # Modules: Foreman
 Adds settings and tasks for managing projects with [foreman].
 

--- a/lib/mina/delayed_job.rb
+++ b/lib/mina/delayed_job.rb
@@ -1,0 +1,16 @@
+# # Modules: delayed_job
+# Adds settings and tasks for background processing
+# with [delayed_job].
+# [delayed_job]: https://rubygems.org/gems/delayed_job
+
+set_default :delayed_job_executable, "bin/delayed_job"
+
+namespace :delayed_job do
+  desc "Restart delayed_job"
+  task :restart do
+    queue %{
+      echo "-----> Restart delayed_job for #{domain}_#{rails_env}"
+      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; mkdir -p tmp/pids ; #{bundle_prefix} #{delayed_job_executable} restart]}
+    }
+  end
+end


### PR DESCRIPTION
task for restarting delayed job. E.g.: 

```ruby

task :deploy => :environment do
  deploy do

    invoke :'git:clone'
    # ...

    to :launch do
      queue  'echo restarting unicorn'
      queue! "service unicorn restart"

      invoke :'delayed_job:restart'
    end
  end
end
```

reason for ` mkdir -p tmp/pids` in the code of PR is that Delayed_job is creating `tmp/pids/delayed_job.pid` if on fresh deployment there is no `tmp` file it will blow up. If `tmp/pids` file exist or it's symlinked it wont do any harm.

Code works on my deployment 