### PR TITLE
Fix link in the support guide

### DIFF
--- a/support/guide.md
+++ b/support/guide.md
@@ -283,7 +283,7 @@ Basic usage:
 
 ### Tasks
 
-There are many tasks available. See the [tasks reference](tasks/index.html), or 
+There are many tasks available. See the [tasks reference](http://mina-deploy.github.io/mina/tasks/), or
 type `mina tasks`.
 
 ### Variables


### PR DESCRIPTION
It currently points to a URL that doesn't exist.
