### PR TITLE
Conditional support for writing a REVISION file

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -55,6 +55,7 @@ namespace :git do
         #{echo_cmd %[git rev-parse HEAD > #{git_revision_file}]} &&
       }
     end
+    write_revision_file ||= ""
 
     status = %[
       echo "-----> Using this git commit" &&

--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -49,6 +49,13 @@ namespace :git do
       }
     end
 
+    write_revision_file = if git_revision_file?
+      %{
+        echo "-----> Writing revision to #{git_revision_file}" &&
+        #{echo_cmd %[git rev-parse HEAD > #{git_revision_file}]} &&
+      }
+    end
+
     status = %[
       echo "-----> Using this git commit" &&
       echo &&
@@ -57,6 +64,6 @@ namespace :git do
       echo
     ]
 
-    queue clone + status
+    queue clone + write_revision_file + status
   end
 end


### PR DESCRIPTION
As mentioned in #72 , having the exact sha of the deployed version of
an application available in the root of the project can be very
handy. For example: it's easy to retrieve the deployed version when the
file is there.

If the user now sets the `git_revision_file` in her `deploy.rb` config
file:

```
set :git_revision_file, 'REVISION'
```

A file named 'REVISION' will be written during deployment which contains
the sha of the project being deployed (obtained via `git rev-parse
HEAD`).

Existing projects won't noticed any difference since the
`git_revision_file` flag must be set to have any effect on the deploy.