### PR TITLE
Add foreman_env option to set environment variable when using `foreman:export` task

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -777,6 +777,9 @@ variable as a default. It should be set, otherwise export command will fail.
 ### foreman_user
 Sets the user under which foreman will execute the service. Defaults to *user*
 
+### foreman_env
+(Optional) Sets environment file that foreman will apply to the upstart files.
+
 ### foreman_log
 Sets the foreman log path. Defaults to *shared/log*
 

--- a/lib/mina/foreman.rb
+++ b/lib/mina/foreman.rb
@@ -40,6 +40,7 @@
 set_default :foreman_app,  lambda { application }
 set_default :foreman_user, lambda { user }
 set_default :foreman_log,  lambda { "#{deploy_to!}/#{shared_path}/log" }
+set_default :foreman_env, nil
 set_default :foreman_sudo, true
 set_default :foreman_format, 'upstart'
 set_default :foreman_location, '/etc/init'
@@ -48,7 +49,8 @@ namespace :foreman do
   desc 'Export the Procfile to Ubuntu upstart scripts'
   task :export do
     sudo_cmd = "sudo" if foreman_sudo
-    export_cmd = "#{sudo_cmd} bundle exec foreman export #{foreman_format} #{foreman_location} -a #{foreman_app} -u #{foreman_user} -d #{deploy_to!}/#{current_path!} -l #{foreman_log}"
+    cmd_option_env = " -e #{foreman_env}" if foreman_env
+    export_cmd = "#{sudo_cmd} bundle exec foreman export #{foreman_format} #{foreman_location} -a #{foreman_app} -u #{foreman_user} -d #{deploy_to!}/#{current_path!} -l #{foreman_log}#{cmd_option_env}"
 
     queue %{
       echo "-----> Exporting foreman procfile for #{foreman_app}"


### PR DESCRIPTION
## Problem

`foreman:export` task doesn't treat `.env` file by default,
so our environment variables specified by `.env` will be ignored.

## Solution

add `foreman_env` option to specify `-e` option when we use `foreman:export` task.