### PR TITLE
Reorder die parameters

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -105,7 +105,7 @@ module Mina
     #     die 2
     #     die 2, "Tests failed"
 
-    def die(code=1, msg=null)
+    def die(msg=nil, code=1)
       str = "Failed with status #{code}"
       str += " (#{msg})" if msg
       err = Failed.new(str)


### PR DESCRIPTION
It is more common to want to specify a custom message than manage custom error levels.