### PR TITLE
fix broken command_queue link

### DIFF
--- a/0.1.2/about_deploy_rb.html
+++ b/0.1.2/about_deploy_rb.html
@@ -49,7 +49,7 @@ end</code></pre>
 
 <p>The <code>queue</code> command queues up Bash commands to be ran on the remote server. If you invoke <code>mina restart</code>, it will invoke the task above and run the queued commands on the remote server <code>your.server.com</code> via SSH.</p>
 
-<p>See <a href='#the_command_queue'>the command queue</a> for more information on the <em>queue</em> command.</p>
+<p>See <a href='command_queue.html'>the command queue</a> for more information on the <em>queue</em> command.</p>
             <section class='footer'>
               <div class='left'>
                 <strong>

--- a/about_deploy_rb.html
+++ b/about_deploy_rb.html
@@ -49,7 +49,7 @@ end</code></pre>
 
 <p>The <code>queue</code> command queues up Bash commands to be ran on the remote server. If you invoke <code>mina restart</code>, it will invoke the task above and run the queued commands on the remote server <code>your.server.com</code> via SSH.</p>
 
-<p>See <a href='#the_command_queue'>the command queue</a> for more information on the <em>queue</em> command.</p>
+<p>See <a href='command_queue.html'>the command queue</a> for more information on the <em>queue</em> command.</p>
             <section class='footer'>
               <div class='left'>
                 <strong>


### PR DESCRIPTION
This fixes the actual broken link, but:

There's some reference to `the_command_queue` instead of `command_queue` in `javascripts/search_index.js`, and I don't know how to generate that file. I ended up at ProScribe after a bit of googling but I seem to need a Scribefile for the generation?