### PR TITLE
Save deployed git sha in deploy/current/.mina_git_revision

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -52,6 +52,7 @@ namespace :git do
     status = %[
       echo "-----> Using this git commit" &&
       echo &&
+      #{echo_cmd %[git rev-parse HEAD > .mina_git_revision]} &&
       #{echo_cmd %[git --no-pager log --format='%aN (%h):%n> %s' -n 1]} &&
       #{echo_cmd %[rm -rf .git]} &&
       echo

--- a/spec/commands/real_deploy_spec.rb
+++ b/spec/commands/real_deploy_spec.rb
@@ -30,6 +30,7 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
     print "[deploy 1]" if ENV['verbose']
     mina 'deploy', '--verbose'
     expect(stdout).to include "-----> Creating a temporary build path"
+    expect(stdout).to include "git rev-parse HEAD > .mina_git_revision"
     expect(stdout).to include "rm -rf .git"
     expect(stdout).to include "mkdir -p"
     expect(File.exists?('deploy/last_version')).to be_truthy
@@ -41,6 +42,7 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
     expect(File.exists?('deploy/current')).to be_truthy
     expect(File.read('deploy/last_version').strip).to eq('1')
     expect(File.exists?('deploy/current/tmp/restart.txt')).to be_truthy
+    expect(File.exists?('deploy/current/.mina_git_revision')).to be_truthy
 
     # And again, to test out sequential versions and stuff
     print "[deploy 2]" if ENV['verbose']
@@ -49,5 +51,6 @@ describe "Invoking the 'mina' command in a project", :ssh => true do
     expect(stdout).not_to include "mkdir -p"
     expect(File.directory?('deploy/releases/2')).to be_truthy
     expect(File.read('deploy/last_version').strip).to eq('2')
+    expect(File.exists?('deploy/current/.mina_git_revision')).to be_truthy
   end
 end


### PR DESCRIPTION
I did not find a proper way of knowing which version is deployed to my servers.

With this, I can have this task in my `config/deploy.rb`:
```
task :revision do
  queue "cat #{deploy_to}/current/.mina_git_revision"
end
```

Maybe this info was stored somewhere, but i have not been able to find it.

Thanks a lot for mina, this is a huge improvement over older deploy plattforms!!!!