### PR TITLE
Fix for #309

### DIFF
--- a/lib/mina/local_helpers.rb
+++ b/lib/mina/local_helpers.rb
@@ -19,15 +19,12 @@ module Mina
     #     local("ls", return: true)
 
     def local(cmd, options = {})
-      require 'shellwords'
-
-      cmd = cmd.join("\n") if cmd.is_a?(Array)
-      script = Shellwords.escape(cmd)
+      script = cmd.join("\n") if cmd.is_a?(Array)
 
       if options[:return] == true
         `#{script}`
       elsif simulate_mode?
-        Local.simulate(cmd)
+        Local.simulate(script)
       else
         result = Local.invoke(script, self)
         Local.ensure_successful result, self
@@ -64,16 +61,18 @@ module Mina
         code = "#{script}"
 
         # Certain environments can't do :pretty mode.
-        term_mode = :exec  if term_mode == :pretty && !pretty_supported?
+        term_mode = :exec if term_mode == :pretty && !pretty_supported?
 
         case term_mode
         when :pretty
+          require 'shellwords'
+          code = Shellwords.escape(code)
           this.pretty_system(code)
         when :exec
-          exec code
+          Kernel.exec code
         else
-          system code
-          $?.to_i
+          Kernel.system code
+          $?.exitstatus
         end
       end
 

--- a/spec/helpers/local_helper_spec.rb
+++ b/spec/helpers/local_helper_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Mina::LocalHelpers::Local do
+  describe '.invoke' do
+    let :scope do
+      double("rake_application").tap do |scope|
+        allow(scope).to receive(:settings).and_return(settings)
+      end
+    end
+
+    let(:settings) { OpenStruct.new }
+
+    it 'uses the pretty system with shell-escaped command when term_mode is set to :pretty and pretty is supported' do
+      settings.term_mode = :pretty
+      cmd = %[echo "hello"]
+
+      allow(described_class).to receive(:pretty_supported?).and_return(true)
+      expect(scope).to receive(:pretty_system).with(Shellwords.escape(cmd)).and_return(0)
+
+      described_class.invoke(cmd, scope)
+    end
+
+    it 'does NOT use the pretty system when term_mode is set to :pretty and pretty is NOT supported' do
+      settings.term_mode = :pretty
+      cmd = %[echo "hello"]
+
+      allow(described_class).to receive(:pretty_supported?).and_return(false)
+      expect(scope).not_to receive(:pretty_system)
+      expect(Kernel).to receive(:exec).and_return(0)
+
+      described_class.invoke(cmd, scope)
+    end
+
+    it 'returns the sub-shell exit status when using the pretty system' do
+      settings.term_mode = :pretty
+
+      allow(described_class).to receive(:pretty_supported?).and_return(true)
+      allow(scope).to receive(:pretty_system).with("return0").and_return(0)
+      allow(scope).to receive(:pretty_system).with("return13").and_return(13)
+
+      expect(described_class.invoke("return0", scope)).to eq 0
+      expect(described_class.invoke("return13", scope)).to eq 13
+    end
+
+    it 'calls Kernel.exec with non shell-escaped command when term_mode is :exec' do
+      settings.term_mode = :exec
+      cmd = %[echo "hello"]
+
+      expect(Kernel).to receive(:exec).with(cmd).and_return(0)
+
+      described_class.invoke(cmd, scope)
+    end
+
+    it 'calls Kernel.system with non shell-escaped command when term_mode is not :pretty nor :exec' do
+      settings.term_mode = nil
+      cmd = %[echo "hello"]
+
+      expect(Kernel).to receive(:system).with(cmd).and_return("hello\n")
+
+      described_class.invoke(cmd, scope)
+    end
+
+    it 'returns the sub-shell exit status when using Kernel.system' do
+      settings.term_mode = nil
+
+      expect(described_class.invoke(%[exit 0], scope)).to eq 0
+      expect(described_class.invoke(%[exit 13], scope)).to eq 13
+    end
+  end
+end

--- a/spec/helpers/local_helper_spec.rb
+++ b/spec/helpers/local_helper_spec.rb
@@ -63,8 +63,8 @@ describe Mina::LocalHelpers::Local do
     it 'returns the sub-shell exit status when using Kernel.system' do
       settings.term_mode = nil
 
-      expect(described_class.invoke(%[exit 0], scope)).to eq 0
-      expect(described_class.invoke(%[exit 13], scope)).to eq 13
+      expect(described_class.invoke(%[/bin/sh -c 'exit 0'], scope)).to eq 0
+      expect(described_class.invoke(%[/bin/sh -c 'exit 13'], scope)).to eq 13
     end
   end
 end


### PR DESCRIPTION
The issue this PR tries to solve is better explained in #309.

Feedback is appreciated, specially regarding tests. I didn't test `Mina::LocalHelpers#local` because I didn't know how to setup the rake scope accordingly. Also I didn't test the return value when `term_mode == :exec` because, well... `Kernel.exec` doesn't return.