### PR TITLE
Clean setup, mina setup fails (Failed with status 1 (1))

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -53,8 +53,8 @@ task :setup => :environment do
   queue  %[echo "-----> Be sure to edit '#{deploy_to}/#{shared_path}/config/database.yml' and 'secrets.yml'."]
 
   queue %[
-    repo_host=`echo $repo | sed -e 's/.*@//g' -e 's/:.*//g'` &&
-    repo_port=`echo $repo | grep -o ':[0-9]*' | sed -e 's/://g'` &&
+    repo_host=`echo #{repository} | sed -e 's/.*@//g' -e 's/:.*//g'` &&
+    repo_port=`echo #{repository} | grep -o ':[0-9]*' | sed -e 's/://g'` &&
     if [ -z "${repo_port}" ]; then repo_port=22; fi &&
     ssh-keyscan -p $repo_port -H $repo_host >> ~/.ssh/known_hosts
   ]


### PR DESCRIPTION
In the default deploy.rb file:

```
  queue %[
    repo_host=`echo $repo | sed -e 's/.*@//g' -e 's/:.*//g'` &&
    repo_port=`echo $repo | grep -o ':[0-9]*' | sed -e 's/://g'` &&
    if [ -z "${repo_port}" ]; then repo_port=22; fi &&
    ssh-keyscan -p $repo_port -H $repo_host >> ~/.ssh/known_hosts
  ]
```

Variable $repo is empty, changed it to #{repository}