### PR TITLE
Fixed bug where the whenever_name was not getting set properly, causing multiple crontab entries.

### DIFF
--- a/lib/mina/whenever.rb
+++ b/lib/mina/whenever.rb
@@ -19,30 +19,33 @@
 # Any and all of these settings can be overriden in your `deploy.rb`.
 
 # ### whenever_name
-# Sets the name for whenever_name.
-
-set_default :whenever_name, "#{domain}_#{rails_env}"
+# Override the default name used by Whenever when clearing,
+# updating or writing the crontab file.
 
 namespace :whenever do
+  # NOTE: setting this as a lambda to allow the user to override
+  # the domain variable at any time in their schedule.rb file
+  name = lambda { whenever_name || "#{domain}_#{rails_env}" }
+
   desc "Clear crontab"
   task :clear => :environment  do
     queue %{
-      echo "-----> Clear crontab for #{whenever_name}"
-      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --clear-crontab #{whenever_name} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
+      echo "-----> Clear crontab for #{name.call}"
+      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --clear-crontab #{name.call} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
     }
   end
   desc "Update crontab"
   task :update => :environment do
     queue %{
-      echo "-----> Update crontab for #{whenever_name}"
-      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --update-crontab #{whenever_name} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
+      echo "-----> Update crontab for #{name.call}"
+      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --update-crontab #{name.call} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
     }
   end
   desc "Write crontab"
   task :write => :environment do
     queue %{
-      echo "-----> Update crontab for #{whenever_name}"
-      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --write-crontab #{whenever_name} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
+      echo "-----> Update crontab for #{name.call}"
+      #{echo_cmd %[cd #{deploy_to!}/#{current_path!} ; #{bundle_bin} exec whenever --write-crontab #{name.call} --set 'environment=#{rails_env}&path=#{deploy_to!}/#{current_path!}']}
     }
   end
 end


### PR DESCRIPTION
I ran into a problem where mina deployments were creating multiple crontab entries.

This was caused because our project's schedule.rb file sets the :domain key *after* requiring 'mina/whenever'.  The code as written was using set_default to set the :whenever_name key at require time.  

I refactored the code to use a lambda which uses the :whenever_name key if defined, otherwise it sets the name to the default name.  This fixes the bug because it is evaluated at runtime, so our :domain key is picked up as defined.  It will also still work with if there is a user-defined :whenever_name variable.