### PR TITLE
Add license to gemspec

### DIFF
--- a/mina.gemspec
+++ b/mina.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/nadarei/mina"
   s.files = `git ls-files`.strip.split("\n")
   s.executables = Dir["bin/*"].map { |f| File.basename(f) }
+  s.licenses = ['MIT']
 
   s.add_dependency "rake"
   s.add_dependency "open4", "~> 1.3.4"


### PR DESCRIPTION
Rubygems.org reads the license field to show the license on the page and to determine the license when the API is queried. It is important that this field is set for tasks such as automating the building of packages.