### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -894,7 +894,7 @@ Override this if you have custom asset paths declared in your Rails's
 The path to be copied to the new release.
 
 The path your assets are compiled to. If your `assets_path` assets have changed,
-this is the folder that gets copied accross from the current release to the new release.
+this is the folder that gets copied across from the current release to the new release.
 
 Override this if you have custom public asset paths.
 


### PR DESCRIPTION
@mina-deploy, I've corrected a typographical error in the documentation of the [mina](https://github.com/mina-deploy/mina) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.