### PR TITLE
Revert "Merge pull request #281 from Bilge/patch-1"

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -125,7 +125,7 @@ module Mina
     #     die 2
     #     die 2, "Tests failed"
 
-    def die(msg=nil, code=1)
+    def die(code=1, msg=null)
       str = "Failed with status #{code}"
       str += " (#{msg})" if msg
       err = Failed.new(str)

--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -125,7 +125,7 @@ module Mina
     #     die 2
     #     die 2, "Tests failed"
 
-    def die(code=1, msg=null)
+    def die(code=1, msg=nil)
       str = "Failed with status #{code}"
       str += " (#{msg})" if msg
       err = Failed.new(str)


### PR DESCRIPTION
This reverts commit 95d857022d3104e722f7dc193f5a0d57062da18d, reversing
changes made to 9315d7ea305c572ccf40d85ade47afb84f366b4f.

This fixes all existing calls to `die`.  It's generally not a good idea to reorder positional parameters.

Examples:
https://github.com/mina-deploy/mina/blob/master/lib/mina/ssh_helpers.rb#L118
https://github.com/mina-deploy/mina/blob/master/lib/mina/local_helpers.rb#L92