### PR TITLE
Add `remove_git_dir` variable; default true

### DIFF
--- a/lib/mina/git.rb
+++ b/lib/mina/git.rb
@@ -12,6 +12,7 @@
 # Sets the branch to be deployed.
 
 set_default :branch, 'master'
+set_default :remove_git_dir, true
 
 namespace :git do
   # ## Deploy tasks
@@ -54,8 +55,12 @@ namespace :git do
       echo &&
       #{echo_cmd %[git rev-parse HEAD > .mina_git_revision]} &&
       #{echo_cmd %[git --no-pager log --format='%aN (%h):%n> %s' -n 1]} &&
-      #{echo_cmd %[rm -rf .git]} &&
-      echo
+    ]
+    if remove_git_dir
+      status += %[#{echo_cmd %[rm -rf .git]} &&
+      ]
+    end
+    status += %[echo
     ]
 
     queue clone + status


### PR DESCRIPTION
This allows me to disable the removal of the `.git` dir which I unfortunately need to get `bower` working for our ember deploys.