### PR TITLE
Fix `in_directory` with `to`

### DIFF
--- a/lib/mina/helpers.rb
+++ b/lib/mina/helpers.rb
@@ -249,7 +249,7 @@ module Mina
     #     commands.should == ['cd ./webapp && (./reload && true)']
 
     def in_directory(path, &blk)
-      isolated_commands = isolate { yield; commands }
+      isolated_commands = isolate { yield; commands(@to) }
       isolated_commands.each { |cmd| queue "(cd #{path} && (#{cmd}))" }
     end
 

--- a/spec/dsl/to_spec.rb
+++ b/spec/dsl/to_spec.rb
@@ -7,7 +7,9 @@ describe 'Mina' do
         queue 'git clone'
 
         to :restart do
-          queue 'touch tmp/restart.txt'
+          in_directory 'tmp' do
+            queue 'touch restart.txt'
+          end
         end
       end
     }
@@ -15,6 +17,6 @@ describe 'Mina' do
     rake { invoke :deploy }
 
     expect(rake.commands).to eq(['git clone'])
-    expect(rake.commands(:restart)).to eq(['touch tmp/restart.txt'])
+    expect(rake.commands(:restart)).to eq(['(cd tmp && (touch restart.txt))'])
   end
 end


### PR DESCRIPTION
When using the `in_directory` helper inside of a task that is invoked within a `to` block all of the queued commands were lost.  This PR teaches `in_directory` to grab the commands from the current bucket instead of always using `:default`.