### PR TITLE
Unforce SSH fingerprints adding to known hosts

### DIFF
--- a/lib/mina/ssh_helpers.rb
+++ b/lib/mina/ssh_helpers.rb
@@ -54,7 +54,6 @@ module Mina
       args << " -p #{port}" if port?
       args << " -A" if forward_agent?
       args << " #{ssh_options}" if ssh_options?
-      args << " -o StrictHostKeyChecking=no"
       args << " -t"
       "ssh #{args}"
     end


### PR DESCRIPTION
fixes #356

removes the option in ssh_helpers being added to known hosts.
this is unnecessary, and causes a security hole for those wanting
to use this library without the need to disable StrictHostKeyChecking
if you want to use this you can use your own ssh_config.