### PR TITLE
make bundle_withouts consistent with bundler

### DIFF
--- a/lib/mina/bundler.rb
+++ b/lib/mina/bundler.rb
@@ -22,7 +22,7 @@ set_default :bundle_path, './vendor/bundle'
 # ### bundle_withouts
 # Sets the colon-separated list of groups to be skipped from installation.
 
-set_default :bundle_withouts, 'development:test'
+set_default :bundle_withouts, 'development test'
 
 # ### bundle_options
 # Sets the options for installing gems via Bundler.


### PR DESCRIPTION
The second block in http://bundler.io/v1.5/groups.html shows that the list of gems is no longer colon-separated but spaced.