### PR TITLE
Add bundle:clean task

### DIFF
--- a/lib/mina/bundler.rb
+++ b/lib/mina/bundler.rb
@@ -46,4 +46,12 @@ namespace :bundle do
       #{echo_cmd %[#{bundle_bin} install #{bundle_options}]}
     }
   end
+
+  desc "Cleans up unused gems in your bundler directory"
+  task :clean do
+    queue %{
+      echo "-----> Cleans up unsed gems"
+      #{echo_cmd %[#{bundle_bin} clean]}
+    }
+  end
 end


### PR DESCRIPTION
Default gems are stored at `./vendor/bundle` dir. When new version gem is installed, the old version gem will not be deleted. Usage of cached gems will be bigger and bigger.

`bundle clean` command could cleans up unused gems in your bundler directory.