### PR TITLE
fix infinite loop in suggested default config

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -20,8 +20,8 @@ set :branch, 'master'
 #   set :forward_agent, true     # SSH forward_agent.
 
 # They will be linked in the 'deploy:link_shared_paths' step.
-# set :shared_dirs, -> { fetch(:shared_dirs, []).push('config') }
-# set :shared_files, -> { fetch(:shared_files, []).push('config/database.yml', 'config/secrets.yml') }
+# set :shared_dirs, fetch(:shared_dirs, []).push('config')
+# set :shared_files, fetch(:shared_files, []).push('config/database.yml', 'config/secrets.yml')
 
 # This task is the environment that is loaded for most commands, such as
 # `mina deploy` or `mina rake`.


### PR DESCRIPTION
I attempted setting up mina today using the latest master (738a8b27ee7c) and I ran into a problem. When I ran `mina setup`, there was an infinite loop of fetch calls. I modified my config/deploy.rb to fix the issue in this way. I suppose I could have posted this as an issue.