### PR TITLE
fix issues with rbenv:load

### DIFF
--- a/tasks/mina/rbenv.rb
+++ b/tasks/mina/rbenv.rb
@@ -2,7 +2,7 @@ set :rbenv_path, "$HOME/.rbenv"
 
 task :'rbenv:load' do
   comment 'Loading rbenv'
-  command "export RBENV_ROOT='#{fetch(:rbenv_path)}'"
+  command %(export RBENV_ROOT="#{fetch(:rbenv_path)}")
   command %(export PATH="#{fetch(:rbenv_path)}/bin:$PATH")
   command %( \\
     if ! which rbenv >/dev/null; then

--- a/tasks/mina/rbenv.rb
+++ b/tasks/mina/rbenv.rb
@@ -3,7 +3,7 @@ set :rbenv_path, "$HOME/.rbenv"
 task :'rbenv:load' do
   comment 'Loading rbenv'
   command "export RBENV_ROOT='#{fetch(:rbenv_path)}'"
-  command "export PATH='#{fetch(:rbenv_path)}/bin:$PATH'"
+  command %(export PATH="#{fetch(:rbenv_path)}/bin:$PATH")
   command %( \\
     if ! which rbenv >/dev/null; then
       echo "! rbenv not found"

--- a/tasks/mina/rbenv.rb
+++ b/tasks/mina/rbenv.rb
@@ -4,12 +4,12 @@ task :'rbenv:load' do
   comment 'Loading rbenv'
   command "export RBENV_ROOT='#{fetch(:rbenv_path)}'"
   command "export PATH='#{fetch(:rbenv_path)}/bin:$PATH'"
-  command %(
+  command %( \\
     if ! which rbenv >/dev/null; then
       echo "! rbenv not found"
       echo "! If rbenv is installed, check your :rbenv_path setting."
       exit 1
-    fi
+    fi \\
   )
   command 'eval "$(rbenv init -)"'
 end


### PR DESCRIPTION
I put the rbenv:load call in my deploy.rb inside an in_path call like so:

```ruby
task :environment do
  in_path(fetch(:deploy_to)) do
    invoke :'rbenv:load'
  end
end
```

This caused a zsh parse error (and I'm assuming bash would have the same problem) because the shell script came out as:

```bash
(cd /deploy/path/current && echo "-----> Loading rbenv" && export RBENV_ROOT='$HOME/.rbenv' && export PATH='$HOME/.rbenv/bin:$PATH' &&  (
    if ! which rbenv >/dev/null; then
      echo "! rbenv not found"
      echo "! If rbenv is installed, check your :rbenv_path setting."
      exit 1
    fi )
   && eval "$(rbenv init -)")
```
