### PR TITLE
add Rbenv and RVM notes

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,6 +30,28 @@ set :domain, 'your.server.com'
 set :deploy_to, '/var/www/flipstack.com'
 ...
 ```
+**Notes:** You may be use the ruby version tool(Rbenv or RVM) to manage ruby and gem, if you use one of than, don't forget uncomment these setting:
+```
+...
+require 'mina/bundler'
+require 'mina/rails'
+require 'mina/git'
+# require 'mina/rbenv'  # for rbenv support. (http://rbenv.org)
+# require 'mina/rvm'    # for rvm support. (http://rvm.io)
+...
+```
+``` ruby
+...
+task :environment do
+  # If you're using rbenv, use this to load the rbenv environment.
+  # Be sure to commit your .ruby-version or .rbenv-version to your repository.
+  # invoke :'rbenv:load'
+
+  # For those using RVM, use this to load an RVM version@gemset.
+  # invoke :'rvm:use[ruby-1.9.3-p125@default]'
+end
+...
+```
 
 ### Step 2: Run 'mina setup'
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -30,7 +30,7 @@ set :domain, 'your.server.com'
 set :deploy_to, '/var/www/flipstack.com'
 ...
 ```
-**Notes:** You may be use the ruby version tool(Rbenv or RVM) to manage ruby and gem, if you use one of than, don't forget uncomment these setting:
+**Notes:** You may be using a ruby versioning tool (rbenv or RVM) to manage ruby and gems. If you are using one of them, don't forget to uncomment these settings:
 ```
 ...
 require 'mina/bundler'


### PR DESCRIPTION
Add Rbenv and RVM notes into Getting_started Doc.

# Details
I deploy my project with Mina step by step according to the document 'getting_started.md', then I encountered an error:
```
bash: line 82 bundle: command not found
```
At last, I found this is caused by my Rbenv environment, I didn't take note of the some comment in **deploy.rb**
```
...
require 'mina/bundler'
require 'mina/rails'
require 'mina/git'
# require 'mina/rbenv'  # for rbenv support. (http://rbenv.org)
# require 'mina/rvm'    # for rvm support. (http://rvm.io)
...
```
``` ruby
...
task :environment do
  # If you're using rbenv, use this to load the rbenv environment.
  # Be sure to commit your .ruby-version or .rbenv-version to your repository.
  # invoke :'rbenv:load'

  # For those using RVM, use this to load an RVM version@gemset.
  # invoke :'rvm:use[ruby-1.9.3-p125@default]'
end
...
```
The Ruby Version Tool(Rbenv or RVM) should be used by most people, so, we may add some notes into the Doc 'getting_started.md' to remind user!
