### PR TITLE
fix rvm parse error

### DIFF
--- a/tasks/mina/rvm.rb
+++ b/tasks/mina/rvm.rb
@@ -8,12 +8,12 @@ task :'rvm:use', :env do |_, args|
   end
 
   comment "Using RVM environment '#{args[:env]}'"
-  command %(
+  command %( \\
     if [[ ! -s "#{fetch(:rvm_path)}" ]]; then
       echo "! Ruby Version Manager not found"
       echo "! If RVM is installed, check your :rvm_path setting."
       exit 1
-    fi
+    fi \\
   )
   command "source #{fetch(:rvm_path)}"
   command "rvm use '#{args[:env]}' --create"
@@ -27,12 +27,12 @@ task :'rvm:wrapper', :env, :name, :bin do |_, args|
   end
 
   comment "creating RVM wrapper '#{args[:name]}_#{args[:bin]}' using '#{args[:env]}'"
-  command %(
+  command %( \\
     if [[ ! -s "#{fetch(:rvm_path)}" ]]; then
       echo "! Ruby Version Manager not found"
       echo "! If RVM is installed, check your :rvm_path setting."
       exit 1
-    fi
+    fi \\
   )
   command "source #{fetch(:rvm_path)}"
   command "rvm wrapper #{args[:env]} #{args[:name]} #{args[:bin]} || exit 1"


### PR DESCRIPTION
Similar to #411, there are parse errors without these extra `\\`.

Maybe there is a more general way to fix this problem with multi-line ifs and chaining with &&?

It does look uglier with the brackets surrounding the if and fi more closely, however.

I suppose also this has been a necessary workaround since mina 0.3.8 as well.

Just brainstorming.