### PR TITLE
fix mina rake bug

### DIFF
--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -94,7 +94,9 @@ make_run_task = lambda { |name, example|
       puts %{You need to provide arguments. Try: mina "#{name}[#{example}]"}
       exit 1
     end
-    command %{cd "#{deploy_to!}/#{current_path!}" && #{fetch(name)} #{arguments}}
+    in_path "#{fetch(:current_path)}" do
+      command %(#{fetch(name)} #{arguments})
+    end
   end
 }
 


### PR DESCRIPTION
This change fixes a bug that prevents me from using `mina rake`:

```
uniqueway-devin:uniqueway devin$ mina rake[oneoff:test_task]
mina aborted!
NoMethodError: undefined method `deploy_to!' for main:Object
Did you mean?  deploy
/Users/devin/.rvm/gems/ruby-2.3.0/gems/mina-1.0.0.beta5/tasks/mina/rails.rb:97:in `block (2 levels) in <top (required)>'
/Users/devin/.rvm/gems/ruby-2.3.0/gems/mina-1.0.0.beta5/lib/mina/application.rb:16:in `run'
/Users/devin/.rvm/gems/ruby-2.3.0/gems/mina-1.0.0.beta5/bin/mina:4:in `<top (required)>'
/Users/devin/.rvm/gems/ruby-2.3.0/bin/mina:23:in `load'
/Users/devin/.rvm/gems/ruby-2.3.0/bin/mina:23:in `<main>'
```