### PR TITLE
change precedence of fetch - fix #414 rvm_path error

### DIFF
--- a/lib/mina/configuration.rb
+++ b/lib/mina/configuration.rb
@@ -23,8 +23,8 @@ module Mina
       variables[key] = block || value
     end
 
-    def fetch(key, default = nil)
-      value = ENV[key.to_s] || variables.fetch(key, default)
+    def fetch(key, default = ENV[key.to_s])
+      value = variables.fetch(key, default)
       value.respond_to?(:call) ? value.call : value
     end
 

--- a/spec/lib/mina/configuration_spec.rb
+++ b/spec/lib/mina/configuration_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Mina::Configuration do
   let(:config) { Class.new(Mina::Configuration).instance }
   let(:key) { config.fetch(:key, :default) }
+  let(:key_no_default) { config.fetch(:key) }
 
   describe '#set' do
     it 'sets by value' do
@@ -17,13 +18,20 @@ describe Mina::Configuration do
   end
 
   describe '#fetch' do
+    it 'returns the set value even if ENV[key] is set' do
+      ENV['key'] = 'env'
+      config.set(:key, :value)
+      expect(key).to eq :value
+      ENV['key'] = nil
+    end
+
     it 'returns the default value if key not set' do
       expect(key).to eq :default
     end
 
-    it 'returns ENV value if set' do
+    it 'returns ENV value if key and default not set' do
       ENV['key'] = 'env'
-      expect(key).to eq 'env'
+      expect(key_no_default).to eq 'env'
       ENV['key'] = nil
     end
   end


### PR DESCRIPTION
Old precedence was to favour ENV[key], then variables[key], then the
default passed to fetch

New precedence is variables[key], then default, then ENV[key]

This fixes #414, in which rvm_path is overridden by the $rvm_path bash
environment variable

I haven't tested this yet