### PR TITLE
Allow to overwrite existing :shared_files with the symlink to shared (fixes #452)

### DIFF
--- a/tasks/mina/deploy.rb
+++ b/tasks/mina/deploy.rb
@@ -27,6 +27,7 @@ namespace :deploy do
     end
 
     fetch(:shared_files, []).each do |linked_path|
+      command %{rm -f "./#{linked_path}"}
       command %{ln -s "#{fetch(:shared_path)}/#{linked_path}" "./#{linked_path}"}
     end
   end

--- a/tasks/mina/deploy.rb
+++ b/tasks/mina/deploy.rb
@@ -27,8 +27,7 @@ namespace :deploy do
     end
 
     fetch(:shared_files, []).each do |linked_path|
-      command %{rm -f "./#{linked_path}"}
-      command %{ln -s "#{fetch(:shared_path)}/#{linked_path}" "./#{linked_path}"}
+      command %{ln -sf "#{fetch(:shared_path)}/#{linked_path}" "./#{linked_path}"}
     end
   end
 


### PR DESCRIPTION
:shared_files like database.yml / secrets.yml are often checked in the repo for development and should be overwritten by the link to the shared file under mina deployment.