### PR TITLE
fix the mina docs link

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -68,4 +68,4 @@ end
 
 # For help in making your deploy script, see the Mina documentation:
 #
-#  - https://github.com/mina-deploy/mina/docs
+#  - http://nadarei.co/mina/


### PR DESCRIPTION
Just a simple fix for the docs link. When first getting started I got a 404 and was a bit confused.