### PR TITLE
fix mina deploy link

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -68,4 +68,4 @@ end
 
 # For help in making your deploy script, see the Mina documentation:
 #
-#  - https://github.com/mina-deploy/mina/docs
+#  - https://github.com/mina-deploy/mina/tree/master/docs


### PR DESCRIPTION
Another PR. This time with the link to the Github docs.

https://github.com/mina-deploy/mina/pull/462#issuecomment-254912878