### PR TITLE
Make `mina console` depend on `environment`.

### DIFF
--- a/tasks/mina/git.rb
+++ b/tasks/mina/git.rb
@@ -33,6 +33,11 @@ namespace :git do
     command %{git --no-pager log --format="%aN (%h):%n> %s" -n 1}
     if fetch(:remove_git_dir)
       command %{rm -rf .git}
+      command %{
+        if [ -f .gitmodules ]; then
+          awk '/path =/ { print $3"/.git" }' .gitmodules | xargs rm -f
+        fi
+      }
     end
   end
 


### PR DESCRIPTION
1. Fix `mina console`
2. Remove `.git` from submodules when removing `.git` folder