### PR TITLE
Update 3rd_party_plugins.md

### DIFF
--- a/docs/3rd_party_plugins.md
+++ b/docs/3rd_party_plugins.md
@@ -32,3 +32,4 @@
 * [mina-tail](https://github.com/modomoto/mina-tail)
 * [mina-unicorn](https://github.com/openteam/mina-unicorn)
 * [mina-whenever](https://github.com/mina-deploy/mina-whenever)
+* [mina-lock] (https://github.com/lorenzosinisi/mina-lock)


### PR DESCRIPTION
Add mina-lock to the list of 3rd party plugins. 

Quite often I found myself in need to ask other developers to not deploy a specific app for some time due to external conditions like a running QA session, a TV commercial, etc. 

In our team we use slack or other communication channels for announcing deployments or asking to 'lock' the deployment of an app. But this is frustrating and every time you need to read those channels in order to know if it is 'ok' to deploy or not. Mina-lock adds a task to lock the deployment writing a file in the current project folder, a concurrent deployment would just fail. I thought this may be useful for other teams as well :)