### PR TITLE
Add support for webpacker:compile task

### DIFF
--- a/spec/support/outputs/rails_webpacker_compile.txt
+++ b/spec/support/outputs/rails_webpacker_compile.txt
@@ -1,0 +1,2 @@
+echo "-----> Precompiling webpacker asset files"
+RAILS_ENV="production" bundle exec rails webpacker:compile

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe 'rails', type: :rake do
     end
   end
 
+  describe 'rails:webpacker_compile' do
+    it 'rails webpacker compile' do
+      expect { invoke_all }.to output(output_file('rails_webpacker_compile')).to_stdout
+    end
+  end
+
   # describe 'rollback' do
   #   it 'rollback' do
   #     expect { invoke_all }.to output(output_file('rollback')).to_stdout

--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -69,6 +69,12 @@ namespace :rails do
       ), quiet: true
     end
   end
+
+  desc 'Compile webpacker assets'
+  task :webpacker_compile do
+    comment %{Precompiling webpacker asset files}
+    command %{#{fetch(:rails)} webpacker:compile}
+  end
 end
 
 def check_for_changes_script(options)


### PR DESCRIPTION
Rails 5.1.beta1 has just been released, and it introduces webpack for managing JS dependencies. The `webpacker:compile` rake task allows compilation of the assets needed for `javascript_pack_tag`. This PR adds support for running this during deployment.

Anyone using webpacker can add this line to their deploy block after `rails:db_migrate`:

    invoke :'rails:webpacker_compile'

You can find more information about webpacker here: https://github.com/rails/webpacker