### PR TITLE
 Fixes 'No Rakefile found' for rails:{db_create, db_migrate, db_rollback, assetts_precompile} commands #524 

### DIFF
--- a/docs/command_line_options.md
+++ b/docs/command_line_options.md
@@ -14,6 +14,8 @@ Beside normal rake options mina added some of its own:
 
 * `-s` / `--simulate` - This will not run any commands; instead, it will simply output the script it builds.
 
+* `-T` / `--tasks` - Shows the tasks available.
+
 * `-V` / `--version` - Shows the current version.
 
 * `-d` / `--debug-configuration-variables` - Display the defined config variables before runnig the tasks.

--- a/spec/support/outputs/rails_assets_precompile.txt
+++ b/spec/support/outputs/rails_assets_precompile.txt
@@ -1,1 +1,7 @@
-if\ diff\ \-qrN\ ".*/deploy/current/vendor/assets/"\ "\./vendor/assets/"\ 2>/dev/null\ &&\ diff\ \-qrN\ ".*/deploy/current/app/assets/"\ "\./app/assets/"\ 2>/dev/null\s*then\s*echo\ "\-\-\-\-\->\ Skipping\ asset\ precompilation"\s*else\s*echo\ "\-\-\-\-\->\ Precompiling\ asset\ files"\s*RAILS_ENV="production"\ bundle\ exec\ rake\ assets:precompile\s*fi
+\(cd .*/deploy/current && if diff -qrN ".*/deploy/current/vendor/assets/" "./vendor/assets/" 2>/dev/null && diff -qrN ".*/deploy/current/app/assets/" "./app/assets/" 2>/dev/null
+then
+  echo "-----> Skipping asset precompilation"
+else
+  echo "-----> Precompiling asset files"
+        RAILS_ENV="production" bundle exec rake assets:precompile
+fi && cd -\)

--- a/spec/support/outputs/rails_db_create.txt
+++ b/spec/support/outputs/rails_db_create.txt
@@ -1,2 +1,1 @@
-echo "-----> Creating database"
-RAILS_ENV="production" bundle exec rake db:create
+\(cd .*/deploy/current && echo "-----> Creating database" && RAILS_ENV="production" bundle exec rake db:create && cd -\)

--- a/spec/support/outputs/rails_db_migrate.txt
+++ b/spec/support/outputs/rails_db_migrate.txt
@@ -1,1 +1,7 @@
-if\ diff\ \-qrN\ ".*deploy/current/db/migrate"\ "\./db/migrate"\ 2>/dev/null\s*then\s*echo\ "\-\-\-\-\->\ DB\ migrations\ unchanged;\ skipping\ DB\ migration"\s*else\s*echo\ "\-\-\-\-\->\ Migrating\ database"\s*RAILS_ENV="production"\ bundle\ exec\ rake\ db:migrate\s*fi
+\(cd .*/deploy/current && if diff -qrN ".*/deploy/current/db/migrate" "./db/migrate" 2>/dev/null
+then
+  echo "-----> DB migrations unchanged; skipping DB migration"
+else
+  echo "-----> Migrating database"
+        RAILS_ENV="production" bundle exec rake db:migrate
+fi && cd -\)

--- a/spec/support/outputs/rails_db_rollback.txt
+++ b/spec/support/outputs/rails_db_rollback.txt
@@ -1,2 +1,1 @@
-echo "-----> Rollbacking database"
-RAILS_ENV="production" bundle exec rake db:rollback
+\(cd .*/deploy/current && echo "-----> Rollbacking database" && RAILS_ENV="production" bundle exec rake db:rollback && cd -\)

--- a/tasks/mina/default.rb
+++ b/tasks/mina/default.rb
@@ -44,7 +44,7 @@ task :ssh_keyscan_repo do
   }
 end
 
-desc 'Adds domain known hosts'
+desc 'Adds domain to the known hosts'
 task :ssh_keyscan_domain do
   ensure!(:domain)
   ensure!(:port)

--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -30,43 +30,55 @@ end
 namespace :rails do
   desc 'Migrate database'
   task :db_migrate do
-    if fetch(:force_migrate)
-      comment %{Migrating database}
-      command %{#{fetch(:rake)} db:migrate}
-    else
-      command check_for_changes_script(
-        at: fetch(:migration_dirs),
-        skip: %{echo "-----> DB migrations unchanged; skipping DB migration"},
-        changed: %{echo "-----> Migrating database"
-          #{echo_cmd("#{fetch(:rake)} db:migrate")}}
-      ), quiet: true
+    set :execution_mode, :exec
+    in_path "#{fetch(:current_path)}" do
+      if fetch(:force_migrate)
+        comment %{Migrating database}
+        command %{#{fetch(:rake)} db:migrate}
+      else
+        command check_for_changes_script(
+          at: fetch(:migration_dirs),
+          skip: %{echo "-----> DB migrations unchanged; skipping DB migration"},
+          changed: %{echo "-----> Migrating database"
+            #{echo_cmd("#{fetch(:rake)} db:migrate")}}
+        ), quiet: true
+      end
     end
   end
 
   desc 'Create database'
   task :db_create do
-    comment %{Creating database}
-    command %{#{fetch(:rake)} db:create}
+    set :execution_mode, :exec
+    in_path "#{fetch(:current_path)}" do
+      comment %{Creating database}
+      command %{#{fetch(:rake)} db:create}
+    end
   end
 
   desc 'Rollback database'
   task :db_rollback do
-    comment %{Rollbacking database}
-    command %{#{fetch(:rake)} db:rollback}
+    set :execution_mode, :exec
+    in_path "#{fetch(:current_path)}" do
+      comment %{Rollbacking database}
+      command %{#{fetch(:rake)} db:rollback}
+    end
   end
 
   desc 'Precompiles assets (skips if nothing has changed since the last release).'
   task :assets_precompile do
-    if fetch(:force_asset_precompile)
-      comment %{Precompiling asset files}
-      command %{#{fetch(:rake)} assets:precompile}
-    else
-      command check_for_changes_script(
-        at: fetch(:asset_dirs),
-        skip: %{echo "-----> Skipping asset precompilation"},
-        changed: %{echo "-----> Precompiling asset files"
-          #{echo_cmd "#{fetch(:rake)} assets:precompile"}}
-      ), quiet: true
+    set :execution_mode, :exec
+    in_path "#{fetch(:current_path)}" do
+      if fetch(:force_asset_precompile)
+        comment %{Precompiling asset files}
+        command %{#{fetch(:rake)} assets:precompile}
+      else
+        command check_for_changes_script(
+          at: fetch(:asset_dirs),
+          skip: %{echo "-----> Skipping asset precompilation"},
+          changed: %{echo "-----> Precompiling asset files"
+            #{echo_cmd "#{fetch(:rake)} assets:precompile"}}
+        ), quiet: true
+      end
     end
   end
 end


### PR DESCRIPTION
 Fixes issue  #524 - 'No Rakefile found' for rails:{db_create, db_migrate, db_rollback, assetts_precompile} commands

I also clarified ssh_keyscan_domain description using style of ssh_keyscan_repo command