### PR TITLE
Add skip-existing option to example rbenv install

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -38,7 +38,7 @@ end
 # Put any custom commands you need to run at setup
 # All paths in `shared_dirs` and `shared_paths` will be created on their own.
 task :setup do
-  # command %{rbenv install 2.3.0}
+  # command %{rbenv install 2.3.0 --skip-existing}
 end
 
 desc "Deploys the current version to the server."


### PR DESCRIPTION
This helps against a hanging connection because it is waiting for `continue with installation? (y/N)`.

```
       rbenv: /home/sunny/.rbenv/versions/2.3.0 already exists
^C
-----> Mina: SIGINT received.
       Shared connection to example.com closed.

       continue with installation? (y/N)
 !     Run Error
```