### PR TITLE
rails commands - assets:clean and schema:load 

### DIFF
--- a/spec/support/outputs/rails_assets_clean.txt
+++ b/spec/support/outputs/rails_assets_clean.txt
@@ -1,0 +1,2 @@
+echo "-----> Removing older assets"
+RAILS_ENV="production" bundle exec rake assets:clean

--- a/spec/support/outputs/rails_db_schema_load.txt
+++ b/spec/support/outputs/rails_db_schema_load.txt
@@ -1,0 +1,2 @@
+echo "-----> DB schema load"
+RAILS_ENV="production" bundle exec rake db:schema:load

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe 'rails', type: :rake do
     end
   end
 
+  describe 'rails:assets_clean' do
+    it 'rails assets clean' do
+      expect { invoke_all }.to output(output_file('rails_assets_clean')).to_stdout
+    end
+  end
   # describe 'rollback' do
   #   it 'rollback' do
   #     expect { invoke_all }.to output(output_file('rollback')).to_stdout

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -42,6 +42,12 @@ RSpec.describe 'rails', type: :rake do
       expect { invoke_all }.to output(output_file('rails_assets_clean')).to_stdout
     end
   end
+
+  describe 'rails:db_schema_load' do
+    it 'rails db schema load' do
+      expect { invoke_all }.to output(output_file('rails_db_schema_load')).to_stdout
+    end
+  end
   # describe 'rollback' do
   #   it 'rollback' do
   #     expect { invoke_all }.to output(output_file('rollback')).to_stdout

--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -69,6 +69,12 @@ namespace :rails do
       ), quiet: true
     end
   end
+
+  desc 'Clear older assets'
+  task :assets_clean do
+    comment %{Removing older assets}
+    command %{#{fetch(:rake)} assets:clean}
+  end
 end
 
 def check_for_changes_script(options)

--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -75,6 +75,12 @@ namespace :rails do
     comment %{Removing older assets}
     command %{#{fetch(:rake)} assets:clean}
   end
+
+  desc 'DB schema load'
+  task :db_schema_load do
+    comment %{DB schema load}
+    command %{#{fetch(:rake)} db:schema:load}
+  end
 end
 
 def check_for_changes_script(options)


### PR DESCRIPTION
We are frequently using these commands in our projects, though adding them to the main would be useful.

* `schema:load` for the initial setup
* `assets:clean` to make sure that we don't end up taking space.