### PR TITLE
Allow use of Minafile or deploy.rb outside of config directory

### DIFF
--- a/lib/mina/application.rb
+++ b/lib/mina/application.rb
@@ -4,7 +4,7 @@ module Mina
 
     def initialize
       super
-      @rakefiles = ['config/deploy.rb', minafile]
+      @rakefiles = ['Minafile', '.deploy.rb', 'deploy.rb', 'config/deploy.rb', minafile]
     end
 
     def name


### PR DESCRIPTION
Not all sites using Mina use Rails, and thus don't always have a config folder in root directory, and would like to keep environment and deploy files in root.