### PR TITLE
Remote environment in deploy example

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -28,7 +28,7 @@ set :branch, 'master'
 
 # This task is the environment that is loaded for all remote run commands, such as
 # `mina deploy` or `mina rake`.
-task :environment do
+task :remote_environment do
   # If you're using rbenv, use this to load the rbenv environment.
   # Be sure to commit your .ruby-version or .rbenv-version to your repository.
   # invoke :'rbenv:load'


### PR DESCRIPTION
After running `mina init` generated `deploy.rb` has `environment` instead of `remote_environment` on line `31`.