### PR TITLE
Allow setting a custom deploy script

### DIFF
--- a/docs/default_plugins.md
+++ b/docs/default_plugins.md
@@ -63,7 +63,7 @@ loads:
   :shared_path            #=> "#{fetch(:deploy_to)}/shared"
   :current_path           #=> "#{fetch(:deploy_to)}/current"
   :lock_file              #=> 'deploy.lock'
-  :deploy_script          #=> 'data/deploy.sh.erb'
+  :deploy_script          #=> Mina.root_path('data/deploy.sh.erb')
   :keep_releases          #=> 5
   :version_scheme         #=> :sequence ## Can be [:sequence, :datetime]
   :shared_dirs            #=> []

--- a/lib/mina/helpers/internal.rb
+++ b/lib/mina/helpers/internal.rb
@@ -5,7 +5,7 @@ module Mina
 
       def deploy_script
         yield
-        erb Mina.root_path(fetch(:deploy_script))
+        erb fetch(:deploy_script)
       end
 
       def erb(file, b = binding)

--- a/spec/lib/mina/helpers/internal_spec.rb
+++ b/spec/lib/mina/helpers/internal_spec.rb
@@ -10,7 +10,7 @@ describe Mina::Helpers::Internal do
 
   describe '#deploy_script' do
     before do
-      Mina::Configuration.instance.set(:deploy_script, 'data/deploy.sh.erb')
+      Mina::Configuration.instance.set(:deploy_script, Mina.root_path('data/deploy.sh.erb'))
       Mina::Configuration.instance.set(:version_scheme, :sequence)
     end
 

--- a/tasks/mina/deploy.rb
+++ b/tasks/mina/deploy.rb
@@ -4,7 +4,7 @@ set :releases_path, -> { "#{fetch(:deploy_to)}/releases" }
 set :shared_path, -> { "#{fetch(:deploy_to)}/shared" }
 set :current_path, -> { "#{fetch(:deploy_to)}/current" }
 set :lock_file, 'deploy.lock'
-set :deploy_script, 'data/deploy.sh.erb'
+set :deploy_script, Mina.root_path('data/deploy.sh.erb')
 set :keep_releases, 5
 set :version_scheme, :sequence
 set :execution_mode, :pretty


### PR DESCRIPTION
In order to use a custom deploy script, we need to monkey patch `Mina::Helpers::Internal` to set a custom path once `Mina::Helpers::Internal#deploy_script` has a hardcoded `Mina.root_path` in it.

This PR allows you to truly use a custom `deploy_script` by doing:

```ruby
set :deploy_script, "/path/to/custom/script"
```