### PR TITLE
Fix for nested linked files

### DIFF
--- a/tasks/mina/deploy.rb
+++ b/tasks/mina/deploy.rb
@@ -35,6 +35,7 @@ namespace :deploy do
     end
 
     fetch(:shared_files, []).each do |linked_path|
+      command %{mkdir -p #{File.dirname("./#{linked_path}")}}
       command %{ln -sf "#{fetch(:shared_path)}/#{linked_path}" "./#{linked_path}"}
     end
   end


### PR DESCRIPTION
When linked files directive has link nested in some dir, e.g. 
```ruby
set :shared_files, fetch(:shared_files, []).push('config/my_secret.yml')
```
and the directory `config` is missing in the release folder, release fail

This is a fix for this case.