### PR TITLE
allow user to overwrite deploy_script

### DIFF
--- a/lib/mina/helpers/internal.rb
+++ b/lib/mina/helpers/internal.rb
@@ -5,7 +5,7 @@ module Mina
 
       def deploy_script
         yield
-        erb Mina.root_path(fetch(:deploy_script))
+        erb fetch(:deploy_script)
       end
 
       def erb(file, b = binding)

--- a/tasks/mina/deploy.rb
+++ b/tasks/mina/deploy.rb
@@ -4,7 +4,7 @@ set :releases_path, -> { "#{fetch(:deploy_to)}/releases" }
 set :shared_path, -> { "#{fetch(:deploy_to)}/shared" }
 set :current_path, -> { "#{fetch(:deploy_to)}/current" }
 set :lock_file, 'deploy.lock'
-set :deploy_script, 'data/deploy.sh.erb'
+set :deploy_script, Mina.root_path('data/deploy.sh.erb')
 set :keep_releases, 5
 set :version_scheme, :sequence
 set :execution_mode, :pretty


### PR DESCRIPTION
Currently, `deploy_script` is overwritable but it's forced under `Mina.root_path` which points the root of this gem.
This causes the option meaningless.

I moved calling `Mina.root_path` not from deploy_script setter but from the option value.
Now user can easily use their on deploy_script.
