### PR TITLE
Corrected typo in part 'bundler'

### DIFF
--- a/docs/default_plugins.md
+++ b/docs/default_plugins.md
@@ -131,7 +131,7 @@ loads:
 
 ## Bundler
 ``` ruby
-require 'mina/bunlder'
+require 'mina/bundler'
 ```
 loads:
 - `mina/default`


### PR DESCRIPTION
There was a typo in the documentation of part bundler