### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/docs/default_plugins.md
+++ b/docs/default_plugins.md
@@ -131,7 +131,7 @@ loads:
 
 ## Bundler
 ``` ruby
-require 'mina/bunlder'
+require 'mina/bundler'
 ```
 loads:
 - `mina/default`


### PR DESCRIPTION
Change 'mina/bunlder' for 'mina/bundler'