### PR TITLE
add a task to open a database console

### DIFF
--- a/spec/support/outputs/dbconsole.txt
+++ b/spec/support/outputs/dbconsole.txt
@@ -1,0 +1,1 @@
+\(cd\ .*/deploy/current\ &&\ RAILS_ENV="production"\ bundle\ exec\ rails\ dbconsole\ &&\ cd\ -\)

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe 'rails', type: :rake do
     end
   end
 
+  describe 'dbconsole' do
+    it 'opens a database console' do
+      expect { invoke_all }.to output(output_file('dbconsole')).to_stdout
+    end
+  end
+
   describe 'log' do
     it 'tails log' do
       expect { invoke_all }.to output(output_file('log')).to_stdout

--- a/tasks/mina/rails.rb
+++ b/tasks/mina/rails.rb
@@ -19,6 +19,14 @@ task :console do
   end
 end
 
+desc 'Starts an interactive database console'
+task :dbconsole do
+  set :execution_mode, :exec
+  in_path "#{fetch(:current_path)}" do
+    command %{#{fetch(:rails)} dbconsole}
+  end
+end
+
 desc 'Tail log from server'
 task :log do
   set :execution_mode, :exec


### PR DESCRIPTION
Added support for running `rails dbconsole`, which opens an interactive command line interface to the app's database.