### PR TITLE
Test suite CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+        ruby: [2.6, 2.7, 3.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
         ruby: [2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-10.15]
         ruby: [2.6, 2.7, 3.0]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Set up a GA workflow for running RSpec test suite.

The suite runs on all combinations of:
- OS: MacOS 10.15 and Ubuntu 20.04
- Ruby: 2.6, 2.7 and 3.0

Windows is excluded for now until the issues are fixed (see https://github.com/mina-deploy/mina/issues/660).
