### PR TITLE
Ensure branch exists locally and remotely before comparing it

### DIFF
--- a/spec/support/outputs/git_ensure_pushed.txt
+++ b/spec/support/outputs/git_ensure_pushed.txt
@@ -1,4 +1,14 @@
 echo "-----> Ensuring everything is pushed to git"
+if \[ \$\(git branch --list master \| wc -l\) -eq 0 \]; then
+  echo "! Branch master doesn't exist locally"
+  exit 1
+fi
+
+if \[ \$\(git ls-remote --heads origin master \| wc -l\) -eq 0 \]; then
+  echo "! Branch master doesn't exist on origin"
+  exit 1
+fi
+
 if \[ \$\(git log origin/master..master \| wc -l\) -ne 0 \]; then
   echo "! Your branch master needs to be pushed to origin before deploying"
   exit 1

--- a/spec/support/outputs/git_ensure_pushed.txt
+++ b/spec/support/outputs/git_ensure_pushed.txt
@@ -1,0 +1,5 @@
+echo "-----> Ensuring everything is pushed to git"
+if \[ \$\(git log origin/master..master \| wc -l\) -ne 0 \]; then
+  echo "! Your branch master needs to be pushed to origin before deploying"
+  exit 1
+fi

--- a/spec/support/outputs/git_ensure_pushed.txt
+++ b/spec/support/outputs/git_ensure_pushed.txt
@@ -1,11 +1,11 @@
 echo "-----> Ensuring everything is pushed to git"
 if \[ \$\(git branch --list master \| wc -l\) -eq 0 \]; then
-  echo "! Branch master doesn't exist locally"
+  echo "! Branch master doesn't exist"
   exit 1
 fi
 
-if \[ \$\(git ls-remote --heads origin master \| wc -l\) -eq 0 \]; then
-  echo "! Branch master doesn't exist on origin"
+if \[ \$\(git branch -r --list origin/master \| wc -l\) -eq 0 \]; then
+  echo "! Branch origin/master doesn't exist"
   exit 1
 fi
 

--- a/spec/tasks/git_spec.rb
+++ b/spec/tasks/git_spec.rb
@@ -18,4 +18,10 @@ RSpec.describe 'git', type: :rake do
       expect { invoke_all }.to output(output_file('git_revision')).to_stdout
     end
   end
+
+  describe 'git:ensure_pushed' do
+    it 'git ensure pushed' do
+      expect { invoke_all }.to output(output_file('git_ensure_pushed')).to_stdout
+    end
+  end
 end

--- a/tasks/mina/git.rb
+++ b/tasks/mina/git.rb
@@ -4,8 +4,8 @@ set :branch, 'master'
 set :remove_git_dir, true
 set :remote, 'origin'
 set :git_not_pushed_message, -> { "Your branch #{fetch(:branch)} needs to be pushed to #{fetch(:remote)} before deploying" }
-set :git_local_branch_missing_message, -> { "Branch #{fetch(:branch)} doesn't exist locally" }
-set :git_remote_branch_missing_message, -> { "Branch #{fetch(:branch)} doesn't exist on #{fetch(:remote)}" }
+set :git_local_branch_missing_message, -> { "Branch #{fetch(:branch)} doesn't exist" }
+set :git_remote_branch_missing_message, -> { "Branch #{fetch(:remote)}/#{fetch(:branch)} doesn't exist" }
 
 namespace :git do
   desc 'Clones the Git repository to the current path.'
@@ -55,7 +55,7 @@ namespace :git do
           exit 1
         fi
 
-        if [ $(git ls-remote --heads #{fetch(:remote)} #{fetch(:branch)} | wc -l) -eq 0 ]; then
+        if [ $(git branch -r --list #{fetch(:remote)}/#{fetch(:branch)} | wc -l) -eq 0 ]; then
           echo "! #{fetch(:git_remote_branch_missing_message)}"
           exit 1
         fi


### PR DESCRIPTION
Fixes #639

If a branch doesn't exist either locally or remotely when `git:ensure_pushed` is invoked, `git log` fails with a weird message (`ambiguous argument 'remote/branch': unknown revision or path not in the working tree`). This fix first checks if the branch exists locally and remotely, then compares it.