### PR TITLE
Exclude documentation from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,13 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})


### PR DESCRIPTION
We only need to run tests when code changes.