### PR TITLE
Refactor pretty printer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15]
-        ruby: [2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0, jruby-head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/docs/how_mina_works.md
+++ b/docs/how_mina_works.md
@@ -152,11 +152,11 @@ Mode | Description
 -----|------------
 `:exec` | It uses [Kernel#exec](http://ruby-doc.org/core-2.4.2/Kernel.html#method-i-exec) to run your script. This means that it will execute and exit and won't run any other tasks. This is useful for tasks such as [`mina console`](https://github.com/mina-deploy/mina/blob/master/tasks/mina/rails.rb#L15)
 `:system` | It uses [Kernel#system](http://ruby-doc.org/core-2.4.2/Kernel.html#method-i-system) to run your script.
-`:pretty` | It uses [Open4#popen4](https://github.com/ahoward/open4/blob/master/lib/open4.rb#L33) to run your script. This mode pretty prints stdout and stderr and colors it. This the default mode for most of the default tasks.
+`:pretty` | It uses [Open3#popen3](https://ruby-doc.org/stdlib-3.0.0/libdoc/open3/rdoc/Open3.html#method-c-popen3) to run your script. This mode pretty prints stdout and stderr and colors it. This the default mode for most of the default tasks.
 `:printer` | It uses [Kernel#puts](http://ruby-doc.org/core-2.4.2/Kernel.html#method-i-puts) to run your script. This is used when `simulate` flag is set so it only prints out the generated script
 
 #### WARNING
-`:pretty` mode is using Popen4. In this mode STDIN is efectivly disabled. This means that any kind of inputs won't be forwarded to remote host. If you have a need for password input please use `:system` mode
+`:pretty` mode is using popen3. In this mode STDIN is efectivly disabled. This means that any kind of inputs won't be forwarded to remote host. If you have a need for password input please use `:system` mode
 
 ### Backends
 

--- a/lib/mina.rb
+++ b/lib/mina.rb
@@ -7,7 +7,7 @@ Rake.application.options.trace = true
 require 'forwardable'
 require 'shellwords'
 require 'singleton'
-require 'open4'
+require 'open3'
 
 require 'mina/version'
 require 'mina/helpers/output'

--- a/mina.gemspec
+++ b/mina.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.5.0'
-  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'awesome_print'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter'

--- a/mina.gemspec
+++ b/mina.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib', 'tasks']
 
   spec.add_dependency 'rake'
-  spec.add_dependency 'open4', '~> 1.3.4'
   spec.add_development_dependency 'rspec', '~> 3.5.0'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'awesome_print'

--- a/spec/lib/mina/runner/pretty_spec.rb
+++ b/spec/lib/mina/runner/pretty_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Mina::Runner::Pretty do
+  subject(:runner) { described_class.new('true') }
+
+  describe '#run', :suppressed_output do
+    it 'executes the script' do
+      expect { runner.run }.to output('').to_stdout
+    end
+
+    it 'returns true', :suppressed_output do
+      expect(runner.run).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Replaces open4 with open3 to remove dependency on an external gem. With this fix the error `NotImplementedError: fork is not available on this platform` is fixed on jruby, so we can support that version of Ruby too (I tested this also by building the gem and trying it out on a project with jruby, it works.). 