### PR TITLE
Prevent stdout output in tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
--c --order rand -t ~ssh
+-c --order rand

--- a/spec/lib/mina/commands_spec.rb
+++ b/spec/lib/mina/commands_spec.rb
@@ -82,7 +82,7 @@ describe Mina::Commands do
   end
 
   describe '#run' do
-    it 'calls run on a backend' do
+    it 'calls run on a backend', :suppressed_output do
       commands.command('ls -al')
       runner = double(:runner)
       allow(Mina::Runner).to receive(:new).and_return(runner)

--- a/spec/lib/mina/configuration_spec.rb
+++ b/spec/lib/mina/configuration_spec.rb
@@ -47,6 +47,7 @@ describe Mina::Configuration do
 
     it 'raises an error if key is not set' do
       expect { config.ensure!(:key) }.to raise_error(SystemExit)
+                                     .and output(/key must be defined!/).to_stdout
     end
   end
 

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'default', type: :rake do
 
     it 'exits if no command given' do
       expect { subject.invoke }.to raise_error(SystemExit)
+                               .and output(/You need to provide a command/).to_stdout
     end
   end
 

--- a/spec/tasks/init_spec.rb
+++ b/spec/tasks/init_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe 'init', type: :rake do
 
   it 'doesnt create deploy rb if already exists' do
     allow(File).to receive(:exist?).and_return(false)
-    expect { subject.invoke }.to raise_error(SystemExit)
+    expect { subject.invoke }.to raise_error(SystemExit).and output(/You already have/).to_stdout
   end
 end


### PR DESCRIPTION
Adds tests for output (so it doesn't go to stdout) and suppresses output where necessary.