### PR TITLE
DSL tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ test_env/deploy
 .rvmrc
 .ruby-gemset
 .ruby-version
-Gemfile.lock
 pkg/
 support/helpers.md
 support/modules.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+PATH
+  remote: .
+  specs:
+    mina (1.2.4)
+      rake
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    awesome_print (1.9.2)
+    codeclimate-test-reporter (1.0.7)
+      simplecov
+    coderay (1.1.3)
+    diff-lcs (1.4.4)
+    docile (1.4.0)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.0.6)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  awesome_print
+  codeclimate-test-reporter
+  mina!
+  pry
+  rspec (~> 3.5.0)
+  simplecov
+
+BUNDLED WITH
+   2.2.25

--- a/spec/configs/default.rb
+++ b/spec/configs/default.rb
@@ -1,0 +1,6 @@
+set :simulate, true
+set :domain, 'localhost'
+set :deploy_to, "#{Dir.pwd}/deploy"
+set :repository, "#{Mina.root_path}"
+set :shared_paths, ['config/database.yml', 'log']
+set :keep_releases, 2

--- a/spec/configs/dsl.rb
+++ b/spec/configs/dsl.rb
@@ -1,0 +1,53 @@
+task :reset_task do
+  command "echo Hello there"
+  reset!
+  command "echo New command"
+end
+
+task :one_run_inside_another do
+  run :local do
+    run :remote do
+      puts "I shouldn't execute"
+    end
+  end
+end
+
+task :local_run do
+  run :local do
+    comment "I am a comment"
+    command "echo Hello there"
+  end
+end
+
+task :remote_run do
+  run :remote do
+    comment "I am a comment"
+    command "echo Hello there"
+  end
+end
+
+task :nonexistent_run do
+  run :nonexistent do
+    comment "I shouldn't run"
+  end
+end
+
+task :on_stage_task do
+  deploy do
+    on :launch do
+      command "echo Hello there"
+    end
+  end
+end
+
+task :in_path_task do
+  in_path '/path' do
+    command "echo Hello there"
+  end
+end
+
+task :deploy_block_task do
+  deploy do
+    command "echo Hello there"
+  end
+end

--- a/spec/lib/mina/application_spec.rb
+++ b/spec/lib/mina/application_spec.rb
@@ -37,12 +37,6 @@ describe Mina::Application do
 
     ['--verbose', '-v'].each do |option|
       describe option do
-        around do |example|
-          original_flag = application.fetch(:verbose)
-          example.run
-          application.set(:verbose, original_flag)
-        end
-
         it 'sets verbose flag to true' do
           expect do
             application.handle_options([option])
@@ -53,12 +47,6 @@ describe Mina::Application do
 
     ['--simulate', '-s'].each do |option|
       describe option do
-        around do |example|
-          original_flag = application.fetch(:simulate)
-          example.run
-          application.set(:simulate, original_flag)
-        end
-
         it 'sets simulate flag to true' do
           expect do
             application.handle_options([option])
@@ -69,12 +57,6 @@ describe Mina::Application do
 
     ['--debug-configuration-variables', '-d'].each do |option|
       describe option do
-        around do |example|
-          original_flag = application.fetch(:debug_configuration_variables)
-          example.run
-          application.set(:debug_configuration_variables, original_flag)
-        end
-
         it 'sets debug_configuration_variables flag to true' do
           expect do
             application.handle_options([option])
@@ -84,12 +66,6 @@ describe Mina::Application do
     end
 
     describe '--no-report-time' do
-      around do |example|
-        original_flag = application.fetch(:skip_report_time)
-        example.run
-        application.set(:skip_report_time, original_flag)
-      end
-
       it 'sets skip_report_time flag to true' do
         expect do
           application.handle_options(['--no-report-time'])

--- a/spec/lib/mina/dsl_spec.rb
+++ b/spec/lib/mina/dsl_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Mina::DSL, type: :rake do
+  before do
+    load_default_config
+    load_config 'dsl'
+  end
+
+  describe '#reset!' do
+    let(:task_name) { 'reset_task' }
+
+    it "clears all commands before it" do
+      expect do
+        invoke_all
+      end.to output(output_file('dsl_reset')).to_stdout
+    end
+  end
+
+  describe '#run' do
+    context 'when one run block is inside another' do
+      let(:task_name) { 'one_run_inside_another' }
+
+      it 'exits with an error message' do
+        expect do
+          invoke_all
+        end.to raise_error(SystemExit)
+           .and output(/Can't use run block inside another run block./).to_stdout
+      end
+    end
+
+    context 'when backend is :local' do
+      let(:task_name) { 'local_run' }
+
+      it 'executes commands locally' do
+        expect do
+          invoke_all
+        end.to output(output_file('dsl_local_run')).to_stdout
+      end
+    end
+
+    context 'when backend is :remote' do
+      let(:task_name) { 'remote_run' }
+
+      it 'executes commands on the server' do
+        expect do
+          invoke_all
+        end.to output(output_file('dsl_remote_run')).to_stdout
+      end
+    end
+    
+    context "when backend doesn't exist" do
+      let(:task_name) { 'nonexistent_run' }
+
+      # TODO: refactor for more user-friendly error handling
+      it 'raises a runtime error' do
+        expect do
+          invoke_all
+        end.to raise_error(RuntimeError, /Don't know how to build task 'nonexistent_environment'/)
+      end
+    end
+  end
+
+  describe '#on' do
+    let(:task_name) { 'on_stage_task' }
+
+    it 'executes the command in the given stage' do
+      expect do
+        invoke_all
+      end.to output(output_file('dsl_on')).to_stdout
+    end
+  end
+
+  describe '#in_path' do
+    let(:task_name) { 'in_path_task' }
+
+    it 'executes the command in the given path' do
+      expect do
+        invoke_all
+      end.to output(output_file('dsl_in_path')).to_stdout
+    end
+  end
+
+  describe '#deploy' do
+    let(:task_name) { 'deploy_block_task' }
+
+    it 'executes the deploy script and commands on remote' do
+      expect do
+        invoke_all
+      end.to output(output_file('dsl_deploy')).to_stdout
+    end
+  end
+end

--- a/spec/lib/mina/helpers/internal_spec.rb
+++ b/spec/lib/mina/helpers/internal_spec.rb
@@ -89,11 +89,8 @@ describe Mina::Helpers::Internal do
   end
 
   describe '#next_version' do
-    around do |example|
-      original_releases_path = Mina::Configuration.instance.remove(:releases_path)
+    before do
       Mina::Configuration.instance.set(:releases_path, '/releases')
-      example.run
-      Mina::Configuration.instance.set(:releases_path, original_releases_path)
     end
 
     context 'when :version_scheme is :datetime' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    Rake.application.tasks.keep_if { |task_name, _| initial_task_names.include?(task_name) }
+    Rake.application.instance_variable_get(:@tasks).keep_if { |task_name, _| initial_task_names.include?(task_name) }
     Rake.application.tasks.each(&:reenable)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
 require 'simplecov'
 
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
+  enable_coverage :branch
+  primary_coverage :branch
+end
 
 require 'mina'
 require 'rspec'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 require 'mina'
 require 'rspec'
 require 'pry'
+require 'set'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 Rake.application = Mina::Application.new
@@ -21,17 +22,16 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.order = 'random'
 
-  config.before(:all, type: :rake) do
-    Mina::Configuration.instance.set :simulate, true
-    Mina::Configuration.instance.set :domain, 'localhost'
-    Mina::Configuration.instance.set :deploy_to, "#{Dir.pwd}/deploy"
-    Mina::Configuration.instance.set :repository, "#{Mina.root_path}"
-    Mina::Configuration.instance.set :shared_paths, ['config/database.yml', 'log']
-    Mina::Configuration.instance.set :keep_releases, 2
+  initial_task_names = Rake.application.tasks.to_set(&:name)
+  initial_variables = Mina::Configuration.instance.variables
+
+  config.before(:each) do
+    Mina::Configuration.instance.instance_variable_set(:@variables, initial_variables.clone)
   end
 
-  config.after(:all, type: :rake) do
-    Mina::Configuration.instance.remove :simulate
+  config.after(:each) do
+    Rake.application.tasks.keep_if { |task_name, _| initial_task_names.include?(task_name) }
+    Rake.application.tasks.each(&:reenable)
   end
 
   config.around(:each, :suppressed_output) do |example|

--- a/spec/support/outputs/dsl_deploy.txt
+++ b/spec/support/outputs/dsl_deploy.txt
@@ -1,0 +1,4 @@
+(?m)#!/usr/bin/env bash
+# Executing the following via 'ssh localhost -p 22 -tt':
+.*
+  echo Hello there

--- a/spec/support/outputs/dsl_in_path.txt
+++ b/spec/support/outputs/dsl_in_path.txt
@@ -1,0 +1,1 @@
+\(cd /path && echo Hello there && cd -\)

--- a/spec/support/outputs/dsl_local_run.txt
+++ b/spec/support/outputs/dsl_local_run.txt
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Executing the following:
+#
+echo "-----> I am a comment"
+echo Hello there

--- a/spec/support/outputs/dsl_on.txt
+++ b/spec/support/outputs/dsl_on.txt
@@ -1,0 +1,6 @@
+# ============================
+# === Start up server => \(in deployer\)
+\(
+cd ".*/deploy/current"
+  echo Hello there
+\) &&

--- a/spec/support/outputs/dsl_remote_run.txt
+++ b/spec/support/outputs/dsl_remote_run.txt
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Executing the following via 'ssh localhost -p 22 -tt':
+#
+echo "-----> I am a comment"
+echo Hello there

--- a/spec/support/outputs/dsl_reset.txt
+++ b/spec/support/outputs/dsl_reset.txt
@@ -1,0 +1,2 @@
+^((?!echo Hello there).)*$
+echo New command

--- a/spec/support/rake_example_group.rb
+++ b/spec/support/rake_example_group.rb
@@ -8,14 +8,15 @@ module RakeExampleGroup
       let(:run_commands) { rake['run_commands']}
       let(:reset!)       { rake['reset!'] }
       subject            { rake[task_name] }
-
-      after do
-        subject.reenable
-        run_commands.reenable
-        reset!.invoke
-        reset!.reenable
-      end
     end
+  end
+
+  def load_default_config
+    load_config 'default'
+  end
+
+  def load_config(config_name)
+    Rake.load_rakefile(Dir.pwd + "/spec/configs/#{config_name}.rb")
   end
 
   def invoke_all(*args)

--- a/spec/support/rake_example_group.rb
+++ b/spec/support/rake_example_group.rb
@@ -3,8 +3,13 @@ module RakeExampleGroup
 
   let(:rake)         { Rake.application }
   let(:task_name)    { self.class.description }
-  let(:run_commands) { rake['run_commands']}
+  let(:run_commands) { rake['run_commands'] }
+  let(:reset!)       { rake['reset!'] }
   subject            { rake[task_name] }
+
+  after(:each) do
+    reset!.invoke
+  end
 
   def load_default_config
     load_config 'default'

--- a/spec/support/rake_example_group.rb
+++ b/spec/support/rake_example_group.rb
@@ -1,15 +1,10 @@
 module RakeExampleGroup
-  extend RSpec::Matchers::DSL
+  extend RSpec::SharedContext
 
-  def self.included(klass)
-    klass.instance_eval do
-      let(:rake)         { Rake.application }
-      let(:task_name)    { self.class.description }
-      let(:run_commands) { rake['run_commands']}
-      let(:reset!)       { rake['reset!'] }
-      subject            { rake[task_name] }
-    end
-  end
+  let(:rake)         { Rake.application }
+  let(:task_name)    { self.class.description }
+  let(:run_commands) { rake['run_commands']}
+  subject            { rake[task_name] }
 
   def load_default_config
     load_config 'default'

--- a/spec/tasks/bundler_spec.rb
+++ b/spec/tasks/bundler_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'bundler', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'bundle:install' do
     it 'bundle install' do
       expect { invoke_all }.to output(output_file('bundle_install')).to_stdout

--- a/spec/tasks/chruby_spec.rb
+++ b/spec/tasks/chruby_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'chruby', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'chruby' do
     subject { rake['chruby'] }
 

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'default', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'environment' do
     it 'outputs a deprecation warning' do
       expect { invoke_all }.to output(output_file('environment')).to_stdout
@@ -18,11 +22,8 @@ RSpec.describe 'default', type: :rake do
     subject { rake['ssh_keyscan_domain'] }
 
     context "when domain isn't set" do
-      around do |example|
-        original_domain = Mina::Configuration.instance.fetch(:domain)
+      before do
         Mina::Configuration.instance.remove(:domain)
-        example.run
-        Mina::Configuration.instance.set(:domain, original_domain)
       end
 
       it 'exits with an error message' do
@@ -34,11 +35,8 @@ RSpec.describe 'default', type: :rake do
     end
 
     context "when port isn't set" do
-      around do |example|
-        original_port = Mina::Configuration.instance.fetch(:port)
+      before do
         Mina::Configuration.instance.remove(:port)
-        example.run
-        Mina::Configuration.instance.set(:port, original_port)
       end
 
       it 'exits with an error message' do

--- a/spec/tasks/deploy_spec.rb
+++ b/spec/tasks/deploy_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'deploy', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'deploy:force_unlock' do
     it 'deploy force_unlock' do
       expect { invoke_all }.to output(output_file('deploy_force_unlock')).to_stdout

--- a/spec/tasks/git_spec.rb
+++ b/spec/tasks/git_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'git', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'git:clone' do
     it 'git clone' do
       expect { invoke_all }.to output(output_file('git_clone')).to_stdout

--- a/spec/tasks/init_spec.rb
+++ b/spec/tasks/init_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'init', type: :rake do
+  before do
+    load_default_config
+  end
+
   it 'creates new deploy rb' do
     allow(File).to receive(:exist?).and_return(true)
     expect(FileUtils).to receive(:mkdir_p)

--- a/spec/tasks/rails_spec.rb
+++ b/spec/tasks/rails_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'rails', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'console' do
     it 'starts console' do
       expect { invoke_all }.to output(output_file('rails_console')).to_stdout
@@ -17,10 +21,8 @@ RSpec.describe 'rails', type: :rake do
     subject { rake['rails:db_migrate'] }
 
     context 'when outside deploy block' do
-      around do |example|
-        original_flag = Mina::Configuration.instance.remove(:deploy_block)
-        example.run
-        Mina::Configuration.instance.set(:deploy_block, original_flag)
+      before do
+        Mina::Configuration.instance.remove(:deploy_block)
       end
 
       it 'exits with an error message' do
@@ -37,11 +39,6 @@ RSpec.describe 'rails', type: :rake do
         Mina::Configuration.instance.set(:deploy_block, true)
       end
 
-      after do
-        Mina::Configuration.instance.remove(:force_migrate)
-        Mina::Configuration.instance.set(:deploy_block, false)
-      end
-
       it 'runs rails db:migrate' do
         expect do
           invoke_all
@@ -52,10 +49,6 @@ RSpec.describe 'rails', type: :rake do
     context 'without force_migrate flag' do
       before do
         Mina::Configuration.instance.set(:deploy_block, true)
-      end
-
-      after do
-        Mina::Configuration.instance.set(:deploy_block, false)
       end
 
       it 'runs rails db:migrate but checks for changes first' do
@@ -82,10 +75,8 @@ RSpec.describe 'rails', type: :rake do
     subject { rake['rails:assets_precompile'] }
 
     context 'when outside deploy block' do
-      around do |example|
-        original_flag = Mina::Configuration.instance.remove(:deploy_block)
-        example.run
-        Mina::Configuration.instance.set(:deploy_block, original_flag)
+      before do
+        Mina::Configuration.instance.remove(:deploy_block)
       end
 
       it 'exits with an error message' do
@@ -102,11 +93,6 @@ RSpec.describe 'rails', type: :rake do
         Mina::Configuration.instance.set(:deploy_block, true)
       end
 
-      after do
-        Mina::Configuration.instance.remove(:force_asset_precompile)
-        Mina::Configuration.instance.set(:deploy_block, false)
-      end
-
       it 'runs rails assets:precompile' do
         expect do
           invoke_all
@@ -117,10 +103,6 @@ RSpec.describe 'rails', type: :rake do
     context 'without force_asset_precompile flag' do
       before do
         Mina::Configuration.instance.set(:deploy_block, true)
-      end
-
-      after do
-        Mina::Configuration.instance.set(:deploy_block, false)
       end
 
       it 'runs rails assets:precompile but checks for changes first' do

--- a/spec/tasks/rbenv_spec.rb
+++ b/spec/tasks/rbenv_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'rbenv', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'rbenv:load' do
     it 'loads rbenv' do
       expect { invoke_all }.to output(output_file('rbenv_load')).to_stdout

--- a/spec/tasks/rvm_spec.rb
+++ b/spec/tasks/rvm_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'rvm', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'rvm:use' do
     subject { rake['rvm:use'] }
 

--- a/spec/tasks/ry_spec.rb
+++ b/spec/tasks/ry_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe 'ry', type: :rake do
+  before do
+    load_default_config
+  end
+
   describe 'ry' do
     subject { rake['ry'] }
 


### PR DESCRIPTION
Adds tests for DSL.

This PR is a bit bigger because in order to achieve testing custom tasks for DSL, I wanted to isolate all specs so that they don't affect each other. Before, if one spec changed the configuration or added a new rake task, these changes would be visible in other specs. With the changes in this PR, each spec should now hopefully be isolated, and one spec's changes shouldn't affect other specs.

This PR also added Gemfile.lock to version control. The reasoning is outlined [here](https://stackoverflow.com/a/68618147), but the specific issue which prompted me into doing this is GA failing because it installed different versions of gems than those which I had locally (you can see the failing test run [here](https://github.com/mina-deploy/mina/runs/3370470649)).