### PR TITLE
Update `compiled_asset_path` in `default_plugins.md`

### DIFF
--- a/docs/default_plugins.md
+++ b/docs/default_plugins.md
@@ -166,7 +166,7 @@ loads:
   :bundle_prefix          #=> %{RAILS_ENV="#{fetch(:rails_env)}" #{fetch(:bundle_bin)} exec}
   :rake                   #=> "#{fetch(:bundle_prefix)} rake"
   :rails                  #=> "#{fetch(:bundle_prefix)} rails"
-  :compiled_asset_path    #=> 'public/assets'
+  :compiled_asset_path    #=> ['public/assets', 'public/packs']
   :asset_dirs             #=> ['vendor/assets/', 'app/assets/']
   :migration_dirs         #=> ['db/migrate']
   :force_migrate          #=> false


### PR DESCRIPTION
Was changed in https://github.com/mina-deploy/mina/pull/656.

I wonder if, for backwards compatibility, we shouldn't leave `compiled_asset_path` alone and create a `compiled_asset_dirs`?

Anyway, this documents the current state.