### PR TITLE
Resolve callables when printing debug_configuration

### DIFF
--- a/tasks/mina/default.rb
+++ b/tasks/mina/default.rb
@@ -37,7 +37,7 @@ task :debug_configuration_variables do
     puts
     puts '------- Printing current config variables -------'
     configuration.variables.each do |key, value|
-      puts "#{key.inspect} => #{value.inspect}"
+      puts "#{key.inspect} => #{(value.respond_to?(:call) ? value.call : value).inspect}"
     end
   end
 end


### PR DESCRIPTION
Otherwise when running `mina -d` you will see lines such as:

```ruby
------- Printing current config variables -------
:debug_configuration_variables => true
:port => 22
:releases_path => #<Proc:0x0000560ef3acbd38...
```