### PR TITLE
Test against Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15]
-        ruby: [2.6, 2.7, 3.0, jruby-head]
+        ruby: [2.6, 2.7, 3.0, 3.1, jruby-head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
-  pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15]
-        ruby: [2.6, 2.7, 3.0, 3.1, jruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, jruby-head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adds Ruby 3.1 to test matrix. Removes CI trigger on PR (`push` is enough). Fixes testing against Ruby 3.0 by passing the version as a string (https://github.com/actions/runner/issues/849).