### PR TITLE
Enable Pretty runner on Windows

### DIFF
--- a/lib/mina/runner.rb
+++ b/lib/mina/runner.rb
@@ -8,7 +8,6 @@ module Mina
 
     def initialize(commands, backend)
       fail 'You must specify execution mode' if execution_mode.nil?
-      fail 'Unsuported execution mode (pretty on windows)' if unsuported_execution_mode?
 
       @backend = backend
       @commands = commands
@@ -31,10 +30,6 @@ module Mina
 
     def script
       Mina::Backend.const_get(class_name_for(backend)).new(commands).prepare
-    end
-
-    def unsuported_execution_mode?
-      execution_mode == :pretty && Gem::Platform.local.os == :windows
     end
 
     def class_name_for(symbol)

--- a/spec/lib/mina/runner_spec.rb
+++ b/spec/lib/mina/runner_spec.rb
@@ -11,12 +11,6 @@ describe Mina::Runner do
       expect { described_class.new(nil, nil) }.to raise_error('You must specify execution mode')
     end
 
-    it 'raises an error when run on windows and pretty print' do
-      instance.set(:execution_mode, :pretty)
-      allow(Gem::Platform.local).to receive(:os).and_return(:windows)
-      expect { described_class.new(nil, nil) }.to raise_error('Unsuported execution mode (pretty on windows)')
-    end
-
     it 'sets execution mode to printer if simulate is true' do
       instance.set(:execution_mode, :pretty)
       instance.set(:simulate, true)


### PR DESCRIPTION
PR #686 refactored the Pretty printer to use the Windows-compatible open3 gem instead of the incompatible open4. This PR removes the guard which prevented users from using the Pretty printer on Windows.

Side note: I don't think this guard ever worked because `Gem::Platform.local.os` won't return `:windows` but `cygwin`, `mswin` or something else.