### PR TITLE
Print correct values in `debug_configuration_variables` task

### DIFF
--- a/spec/support/outputs/debug_configuration_variables.txt
+++ b/spec/support/outputs/debug_configuration_variables.txt
@@ -1,0 +1,9 @@
+========== Configuration variables ==========
+(.|\n)*
+:bundle_bin => "bundle"
+(.|\n)*
+:releases_path => ".*/releases"
+(.|\n)*
+:migration_dirs => \["db/migrate"\]
+(.|\n)*
+========== Configuration variables ==========

--- a/spec/support/outputs/debug_configuration_variables.txt
+++ b/spec/support/outputs/debug_configuration_variables.txt
@@ -4,6 +4,8 @@
 (.|\n)*
 :releases_path => ".*/releases"
 (.|\n)*
+:keep_releases => "1234"
+(.|\n)*
 :migration_dirs => \["db/migrate"\]
 (.|\n)*
 ========== Configuration variables ==========

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -92,10 +92,12 @@ RSpec.describe 'default', type: :rake do
   describe 'debug_configuration_variables' do
     before do
       Mina::Configuration.instance.set(:debug_configuration_variables, true)
+      ENV['keep_releases'] = '1234'
     end
 
     after do
       Mina::Configuration.instance.remove(:debug_configuration_variables)
+      ENV.delete('keep_releases')
     end
 
     it 'prints configuration variables' do

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -90,10 +90,18 @@ RSpec.describe 'default', type: :rake do
   end
 
   describe 'debug_configuration_variables' do
-    it 'prints configrtion variables' do
+    before do
       Mina::Configuration.instance.set(:debug_configuration_variables, true)
-      expect { invoke_all }.to output(/------- Printing current config variables -------/).to_stdout
+    end
+
+    after do
       Mina::Configuration.instance.remove(:debug_configuration_variables)
+    end
+
+    it 'prints configuration variables' do
+      expect do
+        invoke_all
+      end.to output(output_file('debug_configuration_variables')).to_stdout
     end
   end
 end

--- a/tasks/mina/default.rb
+++ b/tasks/mina/default.rb
@@ -34,11 +34,12 @@ end
 
 task :debug_configuration_variables do
   if fetch(:debug_configuration_variables)
-    puts
-    puts '------- Printing current config variables -------'
-    configuration.variables.each do |key, value|
-      puts "#{key.inspect} => #{(value.respond_to?(:call) ? value.call : value).inspect}"
+    puts '========== Configuration variables =========='
+    configuration.variables.each_key do |key|
+      puts "#{key.inspect} => #{fetch(key).inspect}"
     end
+    puts '========== Configuration variables =========='
+    puts
   end
 end
 


### PR DESCRIPTION
Fixes `debug_configuration_variables` task by using `fetch` to resolve the value instead of displaying the raw value from the hash. The previous approach had an issue where when you would override a variable from `config/deploy.rb` with an environment variable, the task would still display the value set in `config/deploy.rb`. This PR also introduces some minor aesthetic changes in the output.