### PR TITLE
Fix `ssh` task escaping

### DIFF
--- a/spec/support/outputs/ssh.txt
+++ b/spec/support/outputs/ssh.txt
@@ -1,1 +1,1 @@
-ssh localhost -p 22 -tt 'cd .*/deploy && exec \$SHELL'
+cd .*/deploy && exec \$SHELL

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -71,19 +71,20 @@ RSpec.describe 'default', type: :rake do
   end
 
   describe 'ssh' do
-    it 'runs ssh when :deploy_to exists' do
+    it 'opens an SSH connection when :deploy_to exists' do
       expect do
         invoke_all
-      end.to output(output_file('ssh')).to_stdout
+      end.to change { Mina::Configuration.instance.fetch(:execution_mode) }.to(:exec)
+         .and output(output_file('ssh')).to_stdout
     end
 
-    it "exits with an error if :deploy_to doesn't exist" do
-      deploy_to = Mina::Configuration.instance.remove(:deploy_to)
+    it "exits with an error message when :deploy_to isn't set" do
+      Mina::Configuration.instance.remove(:deploy_to)
 
-      expect { task.invoke }.to raise_error(SystemExit)
-                               .and output(/deploy_to must be defined!/).to_stdout
-
-      Mina::Configuration.instance.set(:deploy_to, deploy_to)
+      expect do
+        invoke_all
+      end.to raise_error(SystemExit)
+         .and output(/deploy_to must be defined!/).to_stdout
     end
   end
 

--- a/spec/tasks/default_spec.rb
+++ b/spec/tasks/default_spec.rb
@@ -72,11 +72,9 @@ RSpec.describe 'default', type: :rake do
 
   describe 'ssh' do
     it 'runs ssh when :deploy_to exists' do
-      allow(Kernel).to receive(:exec)
-
-      task.invoke
-
-      expect(Kernel).to have_received(:exec).with(output_file('ssh'))
+      expect do
+        invoke_all
+      end.to output(output_file('ssh')).to_stdout
     end
 
     it "exits with an error if :deploy_to doesn't exist" do

--- a/tasks/mina/default.rb
+++ b/tasks/mina/default.rb
@@ -86,8 +86,11 @@ task :run, [:command] do |_, args|
   end
 end
 
-desc 'Opens an SSH session and positions to :deploy_to folder'
+desc 'Open an SSH connection and position to :deploy_to folder'
 task :ssh do
   ensure!(:deploy_to)
-  Kernel.exec %(#{Mina::Backend::Remote.new(nil).ssh} 'cd #{fetch(:deploy_to)} && exec $SHELL')
+
+  set :execution_mode, :exec
+
+  command "cd #{fetch(:deploy_to)} && exec $SHELL"
 end


### PR DESCRIPTION
Refactors `ssh` task to use Mina DSL.

This fixes part of https://github.com/mina-deploy/mina/issues/660 (2nd issue) as the command will now be properly escaped.