### PR TITLE
Remove :bundle_options from bundle clean

### DIFF
--- a/spec/support/outputs/bundle_clean.txt
+++ b/spec/support/outputs/bundle_clean.txt
@@ -1,2 +1,2 @@
-echo "-----> Cleans up unsed gems"
-bundle clean --without development test --path "vendor/bundle" --deployment
+echo "-----> Cleaning up unused gems"
+bundle clean

--- a/tasks/mina/bundler.rb
+++ b/tasks/mina/bundler.rb
@@ -17,7 +17,7 @@ namespace :bundle do
 
   desc 'Cleans up unused gems in your bundler directory'
   task :clean do
-    comment %(Cleans up unsed gems)
-    command %(#{fetch(:bundle_bin)} clean #{fetch(:bundle_options)})
+    comment %(Cleaning up unused gems)
+    command %(#{fetch(:bundle_bin)} clean)
   end
 end


### PR DESCRIPTION
Fixes https://github.com/mina-deploy/mina/issues/521.

Removes interpolation of `:bundle_options` variable from the `bundle clean` command as those options cannot be used in that command.