### PR TITLE
Revert "Deprecate version manager tasks"

### DIFF
--- a/data/deploy.rb
+++ b/data/deploy.rb
@@ -2,10 +2,8 @@
 
 require 'mina/rails'
 require 'mina/git'
-
-# Install https://github.com/mina-deploy/mina-version_managers for rbenv and rvm tasks
-# require 'mina/version_managers/rbenv'  # for rbenv support. (https://rbenv.org)
-# require 'mina/version_managers/rvm'    # for rvm support. (https://rvm.io)
+# require 'mina/rbenv'  # for rbenv support. (https://rbenv.org)
+# require 'mina/rvm'    # for rvm support. (https://rvm.io)
 
 # Basic settings:
 #   domain       - The hostname to SSH to.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,9 +35,8 @@ set :deploy_to, '/var/www/flipstack.com'
 require 'mina/bundler'
 require 'mina/rails'
 require 'mina/git'
-# Install https://github.com/mina-deploy/mina-version_managers for rbenv and rvm tasks
-# require 'mina/version_managers/rbenv'  # for rbenv support. (https://rbenv.org)
-# require 'mina/version_managers/rvm'    # for rvm support. (https://rvm.io)
+# require 'mina/rbenv'  # for rbenv support. (http://rbenv.org)
+# require 'mina/rvm'    # for rvm support. (http://rvm.io)
 ...
 ```
 ``` ruby

--- a/tasks/mina/chruby.rb
+++ b/tasks/mina/chruby.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-unless fetch(:silence_deprecation_warnings)
-  warn '[DEPRECATION] chruby support will be removed from Mina in v2.0.0.'
-  warn '[DEPRECATION] To continue using chruby tasks, install `mina-version_managers` gem and'
-  warn "[DEPRECATION] replace `require 'mina/chruby'` with `require 'mina/version_managers/chruby'`."
-  warn '[DEPRECATION] See https://github.com/mina-deploy/mina-version_managers for more info.'
-  warn '[DEPRECATION] You can silence this message by adding `set :silence_deprecation_warnings, true` to `config/deploy.rb`.'
-  warn ''
-end
-
 set :chruby_path, '/etc/profile.d/chruby.sh'
 
 task :chruby, :env do |_, args|

--- a/tasks/mina/rbenv.rb
+++ b/tasks/mina/rbenv.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-unless fetch(:silence_deprecation_warnings)
-  warn '[DEPRECATION] rbenv support will be removed from Mina in v2.0.0.'
-  warn '[DEPRECATION] To continue using rbenv tasks, install `mina-version_managers` gem and'
-  warn "[DEPRECATION] replace `require 'mina/rbenv'` with `require 'mina/version_managers/rbenv'`."
-  warn '[DEPRECATION] See https://github.com/mina-deploy/mina-version_managers for more info.'
-  warn '[DEPRECATION] You can silence this message by adding `set :silence_deprecation_warnings, true` to `config/deploy.rb`.'
-  warn ''
-end
-
 set :rbenv_path, '$HOME/.rbenv'
 
 task :'rbenv:load' do

--- a/tasks/mina/rvm.rb
+++ b/tasks/mina/rvm.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-unless fetch(:silence_deprecation_warnings)
-  warn '[DEPRECATION] RVM support will be removed from Mina in v2.0.0.'
-  warn '[DEPRECATION] To continue using RVM tasks, install `mina-version_managers` gem and'
-  warn "[DEPRECATION] replace `require 'mina/rvm'` with `require 'mina/version_managers/rvm'`."
-  warn '[DEPRECATION] See https://github.com/mina-deploy/mina-version_managers for more info.'
-  warn '[DEPRECATION] You can silence this message by adding `set :silence_deprecation_warnings, true` to `config/deploy.rb`.'
-  warn ''
-end
-
 set :rvm_use_path, '$HOME/.rvm/scripts/rvm'
 
 task :'rvm:use', :env do |_, args|

--- a/tasks/mina/ry.rb
+++ b/tasks/mina/ry.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-unless fetch(:silence_deprecation_warnings)
-  warn '[DEPRECATION] ry support will be removed from Mina in v2.0.0.'
-  warn '[DEPRECATION] To continue using ry tasks, install `mina-version_managers` gem and'
-  warn "[DEPRECATION] replace `require 'mina/ry'` with `require 'mina/version_managers/ry'`."
-  warn '[DEPRECATION] See https://github.com/mina-deploy/mina-version_managers for more info.'
-  warn '[DEPRECATION] You can silence this message by adding `set :silence_deprecation_warnings, true` to `config/deploy.rb`.'
-  warn ''
-end
-
 set :ry_path, '$HOME/.local'
 
 task :ry, :env do |_, args|


### PR DESCRIPTION
Reverts https://github.com/mina-deploy/mina/pull/709 until a decision is made whether we'll indeed go forward with removing these tasks from the main gem.