### PR TITLE
Modify bundler task to fix deprecation warnings

### DIFF
--- a/spec/support/outputs/bundle_install.txt
+++ b/spec/support/outputs/bundle_install.txt
@@ -1,2 +1,5 @@
 echo "-----> Installing gem dependencies using Bundler"
-bundle install --without development test --path "vendor/bundle" --deployment
+bundle config set --local without 'development test'
+bundle config set --local path 'vendor/bundle'
+bundle config set --local deployment 'true'
+bundle install

--- a/tasks/mina/bundler.rb
+++ b/tasks/mina/bundler.rb
@@ -12,7 +12,10 @@ namespace :bundle do
   desc 'Install gem dependencies using Bundler.'
   task :install do
     comment %(Installing gem dependencies using Bundler)
-    command %(#{fetch(:bundle_bin)} install #{fetch(:bundle_options)})
+    command %(#{fetch(:bundle_bin)} config set --local without '#{fetch(:bundle_withouts)}')
+    command %(#{fetch(:bundle_bin)} config set --local path '#{fetch(:bundle_path)}')
+    command %(#{fetch(:bundle_bin)} config set --local deployment 'true')
+    command %(#{fetch(:bundle_bin)} install)
   end
 
   desc 'Cleans up unused gems in your bundler directory'


### PR DESCRIPTION
Resolves #714.

While configuring mina on my project I noticed deprecation warnings for bundle flags.
I modified the commands in the `bundle:install` task in my project and would like to offer the same changes here.

Refer to [`bundle config` documentation](https://bundler.io/v2.5/man/bundle-config.1.html) for current release 2.5.